### PR TITLE
texinfo patches (strictness): binutils, gdb, gcc

### DIFF
--- a/patches/binutils-2.22-texinfofix.patch
+++ b/patches/binutils-2.22-texinfofix.patch
@@ -1,0 +1,24 @@
+diff -burN orig.binutils-2.22/bfd/doc/bfd.texinfo binutils-2.22/bfd/doc/bfd.texinfo
+--- orig.binutils-2.22/bfd/doc/bfd.texinfo	2010-10-28 13:40:25.000000000 +0200
++++ binutils-2.22/bfd/doc/bfd.texinfo	2013-08-29 22:15:26.795913686 +0200
+@@ -321,9 +321,9 @@
+ @unnumbered BFD Index
+ @printindex cp
+ 
++@c I think something like @colophon should be in texinfo.  In the
++@c meantime:
+ @tex
+-% I think something like @colophon should be in texinfo.  In the
+-% meantime:
+ \long\def\colophon{\hbox to0pt{}\vfill
+ \centerline{The body of this manual is set in}
+ \centerline{\fontname\tenrm,}
+@@ -333,7 +333,7 @@
+ \centerline{{\sl\fontname\tensl\/}}
+ \centerline{are used for emphasis.}\vfill}
+ \page\colophon
+-% Blame: doc@cygnus.com, 28mar91.
+ @end tex
++@c Blame: doc@cygnus.com, 28mar91.
+ 
+ @bye

--- a/patches/gcc-4.6.3-texinfofix.patch
+++ b/patches/gcc-4.6.3-texinfofix.patch
@@ -1,0 +1,110 @@
+diff -burN orig.gcc-4.6.3/gcc/doc/cppopts.texi gcc-4.6.3/gcc/doc/cppopts.texi
+--- orig.gcc-4.6.3/gcc/doc/cppopts.texi	2010-12-20 08:26:12.000000000 +0100
++++ gcc-4.6.3/gcc/doc/cppopts.texi	2013-08-29 22:26:06.740963290 +0200
+@@ -769,7 +769,7 @@
+ Enable special code to work around file systems which only permit very
+ short file names, such as MS-DOS@.
+ 
+-@itemx --help
++@item --help
+ @itemx --target-help
+ @opindex help
+ @opindex target-help
+diff -burN orig.gcc-4.6.3/gcc/doc/generic.texi gcc-4.6.3/gcc/doc/generic.texi
+--- orig.gcc-4.6.3/gcc/doc/generic.texi	2011-01-02 02:30:55.000000000 +0100
++++ gcc-4.6.3/gcc/doc/generic.texi	2013-08-29 22:29:19.734286656 +0200
+@@ -1415,13 +1415,13 @@
+ not matter.  The type of the operands and that of the result are
+ always of @code{BOOLEAN_TYPE} or @code{INTEGER_TYPE}.
+ 
+-@itemx POINTER_PLUS_EXPR
++@item POINTER_PLUS_EXPR
+ This node represents pointer arithmetic.  The first operand is always
+ a pointer/reference type.  The second operand is always an unsigned
+ integer type compatible with sizetype.  This is the only binary
+ arithmetic operand that can operate on pointer types.
+ 
+-@itemx PLUS_EXPR
++@item PLUS_EXPR
+ @itemx MINUS_EXPR
+ @itemx MULT_EXPR
+ These nodes represent various binary arithmetic operations.
+diff -burN orig.gcc-4.6.3/gcc/doc/invoke.texi gcc-4.6.3/gcc/doc/invoke.texi
+--- orig.gcc-4.6.3/gcc/doc/invoke.texi	2012-01-03 17:43:38.000000000 +0100
++++ gcc-4.6.3/gcc/doc/invoke.texi	2013-08-29 22:26:56.847627371 +0200
+@@ -165,7 +165,7 @@
+ -pipe  -pass-exit-codes  @gol
+ -x @var{language}  -v  -###  --help@r{[}=@var{class}@r{[},@dots{}@r{]]}  --target-help  @gol
+ --version -wrapper @@@var{file} -fplugin=@var{file} -fplugin-arg-@var{name}=@var{arg}  @gol
+--fdump-ada-spec@r{[}-slim@r{]}} -fdump-go-spec=@var{file}
++-fdump-ada-spec@r{[}-slim@r{]} -fdump-go-spec=@var{file}}
+ 
+ @item C Language Options
+ @xref{C Dialect Options,,Options Controlling C Dialect}.
+@@ -5085,11 +5085,11 @@
+ @option{-fdump-rtl-ce3} enable dumping after the three
+ if conversion passes.
+ 
+-@itemx -fdump-rtl-cprop_hardreg
++@item -fdump-rtl-cprop_hardreg
+ @opindex fdump-rtl-cprop_hardreg
+ Dump after hard register copy propagation.
+ 
+-@itemx -fdump-rtl-csa
++@item -fdump-rtl-csa
+ @opindex fdump-rtl-csa
+ Dump after combining stack adjustments.
+ 
+@@ -5100,11 +5100,11 @@
+ @option{-fdump-rtl-cse1} and @option{-fdump-rtl-cse2} enable dumping after
+ the two common sub-expression elimination passes.
+ 
+-@itemx -fdump-rtl-dce
++@item -fdump-rtl-dce
+ @opindex fdump-rtl-dce
+ Dump after the standalone dead code elimination passes.
+ 
+-@itemx -fdump-rtl-dbr
++@item -fdump-rtl-dbr
+ @opindex fdump-rtl-dbr
+ Dump after delayed branch scheduling.
+ 
+@@ -5149,7 +5149,7 @@
+ @opindex fdump-rtl-initvals
+ Dump after the computation of the initial value sets.
+ 
+-@itemx -fdump-rtl-into_cfglayout
++@item -fdump-rtl-into_cfglayout
+ @opindex fdump-rtl-into_cfglayout
+ Dump after converting to cfglayout mode.
+ 
+@@ -5179,7 +5179,7 @@
+ @opindex fdump-rtl-rnreg
+ Dump after register renumbering.
+ 
+-@itemx -fdump-rtl-outof_cfglayout
++@item -fdump-rtl-outof_cfglayout
+ @opindex fdump-rtl-outof_cfglayout
+ Dump after converting from cfglayout mode.
+ 
+@@ -5191,7 +5191,7 @@
+ @opindex fdump-rtl-postreload
+ Dump after post-reload optimizations.
+ 
+-@itemx -fdump-rtl-pro_and_epilogue
++@item -fdump-rtl-pro_and_epilogue
+ @opindex fdump-rtl-pro_and_epilogue
+ Dump after generating the function pro and epilogues.
+ 
+diff -burN orig.gcc-4.6.3/gcc/doc/sourcebuild.texi gcc-4.6.3/gcc/doc/sourcebuild.texi
+--- orig.gcc-4.6.3/gcc/doc/sourcebuild.texi	2011-02-11 11:01:29.000000000 +0100
++++ gcc-4.6.3/gcc/doc/sourcebuild.texi	2013-08-29 22:29:01.980954244 +0200
+@@ -676,7 +676,7 @@
+ @code{lang_checks}.
+ 
+ @table @code
+-@itemx all.cross
++@item all.cross
+ @itemx start.encap
+ @itemx rest.encap
+ FIXME: exactly what goes in each of these targets?

--- a/patches/gdb-7.3.1-texinfofix.patch
+++ b/patches/gdb-7.3.1-texinfofix.patch
@@ -1,0 +1,78 @@
+diff -burN orig.gdb-7.3.1/bfd/doc/bfd.texinfo gdb-7.3.1/bfd/doc/bfd.texinfo
+--- orig.gdb-7.3.1/bfd/doc/bfd.texinfo	2010-10-28 13:40:25.000000000 +0200
++++ gdb-7.3.1/bfd/doc/bfd.texinfo	2013-08-29 23:05:29.319533968 +0200
+@@ -321,9 +321,9 @@
+ @unnumbered BFD Index
+ @printindex cp
+ 
++@c I think something like @colophon should be in texinfo.  In the
++@c meantime:
+ @tex
+-% I think something like @colophon should be in texinfo.  In the
+-% meantime:
+ \long\def\colophon{\hbox to0pt{}\vfill
+ \centerline{The body of this manual is set in}
+ \centerline{\fontname\tenrm,}
+@@ -333,7 +333,7 @@
+ \centerline{{\sl\fontname\tensl\/}}
+ \centerline{are used for emphasis.}\vfill}
+ \page\colophon
+-% Blame: doc@cygnus.com, 28mar91.
+ @end tex
++@c Blame: doc@cygnus.com, 28mar91.
+ 
+ @bye
+diff -burN orig.gdb-7.3.1/gdb/doc/gdbint.texinfo gdb-7.3.1/gdb/doc/gdbint.texinfo
+--- orig.gdb-7.3.1/gdb/doc/gdbint.texinfo	2011-02-04 20:10:12.000000000 +0100
++++ gdb-7.3.1/gdb/doc/gdbint.texinfo	2013-08-29 23:09:03.514998167 +0200
+@@ -35,7 +35,7 @@
+ 
+ @titlepage
+ @title @value{GDBN} Internals
+-@subtitle{A guide to the internals of the GNU debugger}
++@subtitle A guide to the internals of the GNU debugger
+ @author John Gilmore
+ @author Cygnus Solutions
+ @author Second Edition:
+diff -burN orig.gdb-7.3.1/gdb/doc/gdb.texinfo gdb-7.3.1/gdb/doc/gdb.texinfo
+--- orig.gdb-7.3.1/gdb/doc/gdb.texinfo	2011-09-04 19:10:37.000000000 +0200
++++ gdb-7.3.1/gdb/doc/gdb.texinfo	2013-08-29 23:07:59.951032483 +0200
+@@ -4792,7 +4792,7 @@
+ 
+ 
+ @kindex advance @var{location}
+-@itemx advance @var{location}
++@item advance @var{location}
+ Continue running the program up to the given @var{location}.  An argument is
+ required, which should be of one of the forms described in
+ @ref{Specify Location}.
+@@ -5582,7 +5582,7 @@
+ @kindex set exec-direction
+ @item set exec-direction
+ Set the direction of target execution.
+-@itemx set exec-direction reverse
++@item set exec-direction reverse
+ @cindex execute forward or backward in time
+ @value{GDBN} will perform all execution commands in reverse, until the
+ exec-direction mode is changed to ``forward''.  Affected commands include
+@@ -36953,9 +36953,9 @@
+ 
+ @printindex cp
+ 
++@c I think something like @colophon should be in texinfo.  In the
++@c meantime:
+ @tex
+-% I think something like @colophon should be in texinfo.  In the
+-% meantime:
+ \long\def\colophon{\hbox to0pt{}\vfill
+ \centerline{The body of this manual is set in}
+ \centerline{\fontname\tenrm,}
+@@ -36966,7 +36966,7 @@
+ \centerline{{\sl\fontname\tensl\/}}
+ \centerline{are used for emphasis.}\vfill}
+ \page\colophon
+-% Blame: doc@cygnus.com, 1991.
+ @end tex
++@c Blame: doc@cygnus.com, 1991.
+ 
+ @bye

--- a/scripts/001-binutils-2.22.sh
+++ b/scripts/001-binutils-2.22.sh
@@ -14,6 +14,7 @@
  ## Enter the source directory and patch the source code.
  cd binutils-2.22
  patch -p1 < ../../patches/binutils-2.22-PSP.patch
+ patch -p1 < ../../patches/binutils-2.22-texinfofix.patch
 
  ## Create and enter the build directory.
  mkdir build-psp

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -25,6 +25,7 @@
  ## Enter the source directory and patch the source code.
  cd gcc-$GCC_VERSION
  patch -p1 < ../../patches/gcc-$GCC_VERSION-PSP.patch
+ patch -p1 < ../../patches/gcc-$GCC_VERSION-texinfofix.patch
 
  ## Unpack the library source code.
  tar xfj ../gmp-$GMP_VERSION.tar.bz2 && ln -s gmp-$GMP_VERSION gmp

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -26,6 +26,7 @@
  ## Enter the source directory and patch the source code.
  cd gcc-$GCC_VERSION
  patch -p1 < ../../patches/gcc-$GCC_VERSION-PSP.patch
+ patch -p1 < ../../patches/gcc-$GCC_VERSION-texinfofix.patch
  
  ## Unpack the library source code.
  tar xfj ../gmp-$GMP_VERSION.tar.bz2 && ln -s gmp-$GMP_VERSION gmp

--- a/scripts/007-gdb-7.3.1.sh
+++ b/scripts/007-gdb-7.3.1.sh
@@ -15,6 +15,7 @@
  cd gdb-7.3.1
  patch -p1 < ../../patches/gdb-7.3.1-fix-stpcpy.patch
  patch -p1 < ../../patches/gdb-7.3.1-PSP.patch
+ patch -p1 < ../../patches/gdb-7.3.1-texinfofix.patch
 
  ## Create and enter the build directory.
  mkdir build-psp


### PR DESCRIPTION
compilation errored out during documentation builds of binutils-2.22, gcc-4.6.3 and gdb-7.3.1.
this is due to new strictness in texinfo.

fixes include:
- replace first @itemx with @item inside @table
- moved comments from inline latex to texinfo (got falsely interpreted by texinfo)
- fixed an option inside a gcc getopts

there are still more non-critical warnings during compilation.

tested on updated archlinux x86_64.
