### PR TITLE
Fix compilation with gcc 4.8

### DIFF
--- a/patches/gcc-4.6.3-fix54638.patch
+++ b/patches/gcc-4.6.3-fix54638.patch
@@ -1,0 +1,19 @@
+--- branches/gcc-4_6-branch/gcc/ira-int.h	2012/09/21 10:08:35	191605
++++ branches/gcc-4_6-branch/gcc/ira-int.h	2012/09/21 10:09:04	191606
+@@ -1123,8 +1123,13 @@
+ ira_allocno_object_iter_cond (ira_allocno_object_iterator *i, ira_allocno_t a,
+ 			      ira_object_t *o)
+ {
+-  *o = ALLOCNO_OBJECT (a, i->n);
+-  return i->n++ < ALLOCNO_NUM_OBJECTS (a);
++  int n = i->n++;
++  if (n < ALLOCNO_NUM_OBJECTS (a))
++    {
++      *o = ALLOCNO_OBJECT (a, n);
++      return true;
++    }
++  return false;
+ }
+ 
+ /* Loop over all objects associated with allocno A.  In each
+

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -26,6 +26,7 @@
  cd gcc-$GCC_VERSION
  patch -p1 < ../../patches/gcc-$GCC_VERSION-PSP.patch
  patch -p1 < ../../patches/gcc-$GCC_VERSION-texinfofix.patch
+ patch -p2 < ../../patches/gcc-$GCC_VERSION-fix54638.patch
 
  ## Unpack the library source code.
  tar xfj ../gmp-$GMP_VERSION.tar.bz2 && ln -s gmp-$GMP_VERSION gmp

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -27,6 +27,7 @@
  cd gcc-$GCC_VERSION
  patch -p1 < ../../patches/gcc-$GCC_VERSION-PSP.patch
  patch -p1 < ../../patches/gcc-$GCC_VERSION-texinfofix.patch
+ patch -p2 < ../../patches/gcc-$GCC_VERSION-fix54638.patch
  
  ## Unpack the library source code.
  tar xfj ../gmp-$GMP_VERSION.tar.bz2 && ln -s gmp-$GMP_VERSION gmp


### PR DESCRIPTION
I had to apply tthis patch in order to use gcc 4.8 to compile psp corss compiler (based on gcc 4.6.3)
http://gcc.gnu.org/bugzilla/show_bug.cgi?id=56938

xan.
