### PR TITLE
add dependency header path for osx 10.9

### DIFF
--- a/depends/check-ncurses.sh
+++ b/depends/check-ncurses.sh
@@ -5,4 +5,5 @@
  ls /usr/include/ncurses.h 1> /dev/null ||
  ls /usr/include/ncurses/ncurses.h 1> /dev/null ||
  ls /usr/local/include/ncurses.h 1> /dev/null ||
+ ls /opt/local/include/ncurses.h 1> /dev/null ||
  { echo "ERROR: Install ncurses before continuing."; exit 1; }

--- a/depends/check-readline.sh
+++ b/depends/check-readline.sh
@@ -4,4 +4,5 @@
  ## Check for the readline library.
  ls /usr/include/readline/readline.h 1> /dev/null || \
  ls /usr/local/include/readline/readline.h 1> /dev/null || \
+ ls /opt/local/include/readline/readline.h 1> /dev/null || \
  { echo "ERROR: Install readline before continuing."; exit 1; }

--- a/depends/check-zlib.sh
+++ b/depends/check-zlib.sh
@@ -5,4 +5,5 @@
  ## Check for the z library.
  ls /usr/include/zlib.h 1> /dev/null ||
  ls /usr/local/include/zlib.h 1> /dev/null ||
+ ls /opt/local/include/zlib.h 1> /dev/null ||
  { echo "ERROR: Install zlib before continuing."; exit 1; }


### PR DESCRIPTION
I tested the building procedure, added header paths needed for using macport on OSX 10.9
