### PR TITLE
Fix GDB duplicate symbol _sim_addr_range_hit_p under Mac OS 10.9

### DIFF
--- a/patches/gdb-7.3.1-fix-sim-arange.patch
+++ b/patches/gdb-7.3.1-fix-sim-arange.patch
@@ -1,0 +1,22 @@
+--- gdb-7.3.1.orig/sim/common/sim-arange.h	2014-04-10 14:07:37.000000000 +1000
++++ gdb-7.3.1/sim/common/sim-arange.h	2014-04-10 14:05:43.000000000 +1000
+@@ -62,17 +62,13 @@
+
+ /* Return non-zero if ADDR is in range AR, traversing the entire tree.
+    If no range is specified, that is defined to mean "everything".  */
+-extern INLINE int
++static INLINE int
+ sim_addr_range_hit_p (ADDR_RANGE * /*ar*/, address_word /*addr*/);
+ #define ADDR_RANGE_HIT_P(ar, addr) \
+   ((ar)->range_tree == NULL || sim_addr_range_hit_p ((ar), (addr)))
+
+ #ifdef HAVE_INLINE
+-#ifdef SIM_ARANGE_C
+-#define SIM_ARANGE_INLINE INLINE
+-#else
+-#define SIM_ARANGE_INLINE EXTERN_INLINE
+-#endif
++#define SIM_ARANGE_INLINE static INLINE
+ #include "sim-arange.c"
+ #else
+ #define SIM_ARANGE_INLINE

--- a/scripts/007-gdb-7.3.1.sh
+++ b/scripts/007-gdb-7.3.1.sh
@@ -16,6 +16,7 @@
  patch -p1 < ../../patches/gdb-7.3.1-fix-stpcpy.patch
  patch -p1 < ../../patches/gdb-7.3.1-PSP.patch
  patch -p1 < ../../patches/gdb-7.3.1-texinfofix.patch
+ patch -p1 < ../../patches/gdb-7.3.1-fix-sim-arange.patch
 
  ## Create and enter the build directory.
  mkdir build-psp


### PR DESCRIPTION
Fix duplicate symbol _sim_addr_range_hit_p under Mac OS 10.9
