### PR TITLE
Actually fail if dependencies are not found

### DIFF
--- a/depends/check-dependencies.sh
+++ b/depends/check-dependencies.sh
@@ -93,4 +93,5 @@ if [ ${#missing_depends[@]} -ne 0 ]; then
     for dep in $missing_depends; do
         echo "  - $dep"
     done
+	exit 1
 fi


### PR DESCRIPTION
I tested dependency detection quite extensively, but forgot to actually error out when one isn't found…
