### PR TITLE
Add libsdl1.2-dev to get sdl-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Ubuntu
 
 1. Install the required packages by running.
 
-        sudo apt-get install g++ build-essential autoconf automake automake1.9 cmake doxygen bison flex libncurses5-dev libreadline-dev libusb-dev texinfo libgmp3-dev libmpfr-dev libelf-dev libmpc-dev libfreetype6-dev zlib1g-dev libtool subversion git tcl unzip libsdl1.2-dev
+        sudo apt-get install g++ build-essential autoconf automake automake1.9 cmake doxygen bison flex libncurses5-dev libreadline-dev libusb-dev texinfo libgmp3-dev libmpfr-dev libelf-dev libmpc-dev libfreetype6-dev zlib1g-dev libtool subversion git tcl unzip libsdl-dev
 
 2. Build and install the toolchain and SDK.
 


### PR DESCRIPTION
Need to install libsdl1.2-dev for sdl-config (Ubuntu 14.04). Not sure if other Ubuntu versions do the same.
