### PR TITLE
udev rule to allow `usbhostfs_pc` to work without sudo

### DIFF
--- a/dist/99-psplink.rules
+++ b/dist/99-psplink.rules
@@ -1,0 +1,11 @@
+# 
+# Make sure Type-B PSPs are mounted with Mode 0666 (world-writable).
+# This removes the need to run `usbhostfs_pc` as root.
+# 
+# To install, copy this file to:
+#     /etc/udev/rules.d/99-psplink.rules
+# 
+# Note: The filename is important; it must start with a number higher
+# than 50, otherwise MODE changes will not take effect!
+# 
+ATTR{idVendor}=="054c", ATTR{idProduct}=="01c9", MODE="0666"

--- a/prepare-debian-ubuntu.sh
+++ b/prepare-debian-ubuntu.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# `cd` into the toolchain directory, to be able to use relative paths
+cd $(dirname $0)
+
 # Install build dependencies
 sudo apt-get install $@ g++ build-essential autoconf automake automake1.9 cmake doxygen bison flex libncurses5-dev libsdl1.2-dev libreadline-dev libusb-dev texinfo libgmp3-dev libmpfr-dev libelf-dev libmpc-dev libfreetype6-dev zlib1g-dev libtool subversion git tcl unzip
 
@@ -9,3 +12,7 @@ sudo apt-get install $@ g++ build-essential autoconf automake automake1.9 cmake 
 # instead of the intended program.
 sudo true; echo "dash dash/sh boolean false" | sudo debconf-set-selections
 sudo dpkg-reconfigure --frontend=noninteractive dash
+
+# Make Type-B PSP devices (eg. PSPs running PSPLink) mount world-writable,
+# removing the need to run usbhostfs_pc as root. See above for `sudo true`.
+sudo true; sudo cp dist/99-psplink.rules /etc/udev/rules.d/99-psplink.rules


### PR DESCRIPTION
We can just force all devices identifying as Type-B PSPs to mount with Mode `666`.
