### PR TITLE
fix gcc5 build

### DIFF
--- a/patches/patch-gcc_cp_cfns.h
+++ b/patches/patch-gcc_cp_cfns.h
@@ -1,0 +1,22 @@
+--- gcc/cp/cfns.h.orig	2015-02-13 08:27:46.000000000 +0200
++++ gcc/cp/cfns.h	2015-02-13 10:23:53.000000000 +0200
+@@ -53,6 +53,9 @@
+ static unsigned int hash (const char *, unsigned int);
+ #ifdef __GNUC__
+ __inline
++#ifdef __GNUC_STDC_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
+ #endif
+ const char * libc_name_p (const char *, unsigned int);
+ /* maximum key range = 391, duplicates = 0 */
+@@ -96,7 +99,7 @@
+       400, 400, 400, 400, 400, 400, 400, 400, 400, 400,
+       400, 400, 400, 400, 400, 400, 400
+     };
+-  register int hval = len;
++  register int hval = (int)len;
+ 
+   switch (hval)
+     {
+

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -22,6 +22,7 @@
  ## Enter the source directory and patch the source code.
  cd gcc-$GCC_VERSION
  patch -p1 -i ../../patches/gcc-$GCC_VERSION-PSP.patch
+ patch -p0 -i ../../patches/patch-gcc_cp_cfns.h
 
  ## Unpack the library source code.
  ln -fs ../gmp-$GMP_VERSION gmp


### PR DESCRIPTION
gcc 4.6.4 must be patched in order to compile with gcc 5.1.0:
https://github.com/DragonFlyBSD/DPorts/issues/136