### PR TITLE
fix typo in newlib patch

### DIFF
--- a/patches/newlib-1.20.0-PSP.patch
+++ b/patches/newlib-1.20.0-PSP.patch
@@ -7266,7 +7266,7 @@ diff -burN orig.newlib-1.20.0/newlib/libc/sys/psp/Makefile.am newlib-1.20.0/newl
 +LIBCGLUE_MULT_OBJS = _close.o _exit.o _fork.o _fstat.o _getpid.o \
 +                     _gettimeofday.o _kill.o _lseek.o _open.o _read.o \
 +                     _sbrk.o _wait.o _write.o clock.o isatty.o _isatty.o \
-+                     time.o_link.o _unlink.o sleep.o opendir.o readdir.o \
++                     time.o _link.o _unlink.o sleep.o opendir.o readdir.o \
 +                     closedir.o getcwd.o chdir.o mkdir.o rmdir.o \
 +                     realpath.o _stat.o truncate.o access.o tzset.o \
 +                     __psp_set_errno.o mlock.o _fcntl.o _rename.o nanosleep.o
@@ -7511,7 +7511,7 @@ diff -burN orig.newlib-1.20.0/newlib/libc/sys/psp/Makefile.in newlib-1.20.0/newl
 +LIBCGLUE_MULT_OBJS = _close.o _exit.o _fork.o _fstat.o _getpid.o \
 +                     _gettimeofday.o _kill.o _lseek.o _open.o _read.o \
 +                     _sbrk.o _wait.o _write.o clock.o isatty.o _isatty.o \
-+                     time.o_link.o _unlink.o sleep.o opendir.o readdir.o \
++                     time.o _link.o _unlink.o sleep.o opendir.o readdir.o \
 +                     closedir.o getcwd.o chdir.o mkdir.o rmdir.o \
 +                     realpath.o _stat.o truncate.o access.o tzset.o \
 +                     __psp_set_errno.o mlock.o _fcntl.o _rename.o nanosleep.o


### PR DESCRIPTION
this causes undefineds references to _link in libc.a and maybe some other time functions