### PR TITLE
Removing automake 1.9 from dependencies in order to run on Ubuntu 16.04 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Ubuntu
 
 1. Install the required packages by running.
 
-        sudo apt-get install g++ build-essential autoconf automake automake1.9 cmake doxygen bison flex libncurses5-dev libsdl1.2-dev libreadline-dev libusb-dev texinfo libgmp3-dev libmpfr-dev libelf-dev libmpc-dev libfreetype6-dev zlib1g-dev libtool libtool-bin subversion git tcl unzip
+        sudo apt-get install g++ build-essential autoconf automake cmake doxygen bison flex libncurses5-dev libsdl1.2-dev libreadline-dev libusb-dev texinfo libgmp3-dev libmpfr-dev libelf-dev libmpc-dev libfreetype6-dev zlib1g-dev libtool libtool-bin subversion git tcl unzip
 
 2. Build and install the toolchain and SDK.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Ubuntu
 
 1. Install the required packages by running.
 
-        sudo apt-get install g++ build-essential autoconf automake cmake doxygen bison flex libncurses5-dev libsdl1.2-dev libreadline-dev libusb-dev texinfo libgmp3-dev libmpfr-dev libelf-dev libmpc-dev libfreetype6-dev zlib1g-dev libtool libtool-bin subversion git tcl unzip
+        sudo apt-get install g++ build-essential autoconf automake cmake doxygen bison flex libncurses5-dev libsdl1.2-dev libreadline-dev libusb-dev texinfo libgmp3-dev libmpfr-dev libelf-dev libmpc-dev libfreetype6-dev zlib1g-dev libtool libtool-bin subversion git tcl unzip wget
 
 2. Build and install the toolchain and SDK.
 

--- a/depends/check-dependencies.sh
+++ b/depends/check-dependencies.sh
@@ -81,7 +81,6 @@ check_program   unzip
 
 check_program   autoconf
 check_program   automake
-check_program   automake-1.9    # This particular version is needed too
 check_program   cmake
 check_program   make
 check_program   gcc


### PR DESCRIPTION
The toolchain runs fine without this dependency.