### PR TITLE
Replace insecure URLs

### DIFF
--- a/prepare-mac-os.sh
+++ b/prepare-mac-os.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 install_libusb() {
-	wget --continue http://downloads.sourceforge.net/project/libusb/libusb-0.1%20%28LEGACY%29/0.1.12/libusb-0.1.12.tar.gz -O libusb-legacy.tar.gz
+	wget --continue https://downloads.sourceforge.net/project/libusb/libusb-0.1%20%28LEGACY%29/0.1.12/libusb-0.1.12.tar.gz -O libusb-legacy.tar.gz
 	rm -Rf libusb-legacy && mkdir libusb-legacy && tar --strip-components=1 --directory=libusb-legacy -xzf libusb-legacy.tar.gz
 	cd libusb-legacy
 	./configure && make CFLAGS="-Wno-error" CPPFLAGS="-Wno-error" && make install

--- a/scripts/001-binutils-2.22.sh
+++ b/scripts/001-binutils-2.22.sh
@@ -5,7 +5,7 @@
  set -e
 
  ## Download the source code if it does not already exist.
- download_and_extract ftp://ftp.gnu.org/pub/gnu/binutils/binutils-2.22.tar.bz2 binutils-2.22
+ download_and_extract https://ftp.gnu.org/pub/gnu/binutils/binutils-2.22.tar.bz2 binutils-2.22
 
  ## Enter the source directory and patch the source code.
  cd binutils-2.22

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -11,12 +11,12 @@
  set -e
 
  ## Download the source code if it does not already exist.
- download_and_extract ftp://ftp.gnu.org/pub/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2 gcc-$GCC_VERSION
+ download_and_extract https://ftp.gnu.org/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2 gcc-$GCC_VERSION
 
  ## Download the library source code if it does not already exist.
- download_and_extract http://gmplib.org/download/gmp/gmp-$GMP_VERSION.tar.bz2 gmp-$GMP_VERSION
- download_and_extract http://www.multiprecision.org/mpc/download/mpc-$MPC_VERSION.tar.gz mpc-$MPC_VERSION
- download_and_extract http://www.mpfr.org/mpfr-$MPFR_VERSION/mpfr-$MPFR_VERSION.tar.bz2 mpfr-$MPFR_VERSION
+ download_and_extract https://ftp.gnu.org/gnu/gmp/gmp-$GMP_VERSION.tar.bz2 gmp-$GMP_VERSION
+ download_and_extract https://ftp.gnu.org/gnu/mpc/mpc-$MPC_VERSION.tar.gz mpc-$MPC_VERSION
+ download_and_extract https://ftp.gnu.org/gnu/mpfr/mpfr-$MPFR_VERSION.tar.bz2 mpfr-$MPFR_VERSION
 
  ## Enter the source directory and patch the source code.
  cd gcc-$GCC_VERSION

--- a/scripts/004-newlib-1.20.0.sh
+++ b/scripts/004-newlib-1.20.0.sh
@@ -5,7 +5,7 @@
  set -e
 
  ## Download the source code if it does not already exist.
- download_and_extract ftp://sourceware.org/pub/newlib/newlib-1.20.0.tar.gz newlib-1.20.0
+ download_and_extract https://sourceware.org/pub/newlib/newlib-1.20.0.tar.gz newlib-1.20.0
 
  ## Enter the source directory and patch the source code.
  cd newlib-1.20.0

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -7,17 +7,17 @@
  GMP_VERSION=5.1.3
  MPC_VERSION=1.0.2
  MPFR_VERSION=3.1.2
- 
+
  ## Exit on errors
  set -e
 
  ## Download the source code if it does not already exist.
- download_and_extract ftp://ftp.gnu.org/pub/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2 gcc-$GCC_VERSION
+ download_and_extract https://ftp.gnu.org/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2 gcc-$GCC_VERSION
 
  ## Download the library source code if it does not already exist.
- download_and_extract ftp://ftp.gmplib.org/pub/gmp-$GMP_VERSION/gmp-$GMP_VERSION.tar.bz2 gmp-$GMP_VERSION
- download_and_extract http://www.multiprecision.org/mpc/download/mpc-$MPC_VERSION.tar.gz mpc-$MPC_VERSION
- download_and_extract http://www.mpfr.org/mpfr-$MPFR_VERSION/mpfr-$MPFR_VERSION.tar.bz2 mpfr-$MPFR_VERSION
+ download_and_extract https://ftp.gnu.org/gnu/gmp/gmp-$GMP_VERSION.tar.bz2 gmp-$GMP_VERSION
+ download_and_extract https://ftp.gnu.org/gnu/mpc/mpc-$MPC_VERSION.tar.gz mpc-$MPC_VERSION
+ download_and_extract https://ftp.gnu.org/gnu/mpfr/mpfr-$MPFR_VERSION.tar.bz2 mpfr-$MPFR_VERSION
 
  ## Enter the source directory and patch the source code.
  cd gcc-$GCC_VERSION

--- a/scripts/007-gdb-7.3.1.sh
+++ b/scripts/007-gdb-7.3.1.sh
@@ -5,7 +5,7 @@
  set -e
 
  ## Download the source code if it does not already exist.
- download_and_extract ftp://ftp.gnu.org/pub/gnu/gdb/gdb-7.3.1.tar.bz2 gdb-7.3.1
+ download_and_extract https://ftp.gnu.org/gnu/gdb/gdb-7.3.1.tar.bz2 gdb-7.3.1
 
  ## Enter the source directory and patch the source code.
  cd gdb-7.3.1

--- a/scripts/008-insight-6.8.sh
+++ b/scripts/008-insight-6.8.sh
@@ -6,7 +6,7 @@ exit;
  set -e
 
  ## Download the source code if it does not already exist.
- download_and_extract ftp://sourceware.org/pub/insight/releases/insight-6.8a.tar.bz2 insight-6.8
+ download_and_extract https://sourceware.org/pub/insight/releases/insight-6.8a.tar.bz2 insight-6.8
 
  ## Enter the source directory and patch the source code.
  cd insight-6.8


### PR DESCRIPTION
gnu.org is [disabling ftp completely](https://ftp.gnu.org/CRYPTO.README) at some point in the future so those URLs must be changed or else the scripts will just break. This changeset also replaces all the other insecure URLs with HTTPS URLs. Ideally PGP signature verification would be performed, but this is a reasonable stop-gap measure to at least prevent modification of data in transit.