### PR TITLE
Removed stale automake1.9 and added libtool-bin for "libtool" binary.

### DIFF
--- a/prepare-debian-ubuntu.sh
+++ b/prepare-debian-ubuntu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install build dependencies
-sudo apt-get install $@ g++ build-essential autoconf automake automake1.9 cmake doxygen bison flex libncurses5-dev libsdl1.2-dev libreadline-dev libusb-dev texinfo libgmp3-dev libmpfr-dev libelf-dev libmpc-dev libfreetype6-dev zlib1g-dev libtool subversion git tcl unzip
+sudo apt-get install $@ g++ build-essential autoconf automake cmake doxygen bison flex libncurses5-dev libsdl1.2-dev libreadline-dev libusb-dev texinfo libgmp3-dev libmpfr-dev libelf-dev libmpc-dev libfreetype6-dev zlib1g-dev libtool libtool-bin subversion git tcl unzip
 
 # Make `/bin/sh` an alias for `/bin/bash` instead of `/bin/dash` - which is
 # faster, but doesn't play nice with some autotools scripts in psp-ports.


### PR DESCRIPTION
I've updated the prepare-debian-ubuntu.sh script to remove the automake1.9 install line. Also, it was missing the libtool-BIN package or the toolchain script fails because it won't be able to find the libtool binary, only "libtoolize".

Thanks in advance!