### PR TITLE
Updating to gcc 5.4.0.

### DIFF
--- a/patches/gcc-5.4.0-PSP.patch
+++ b/patches/gcc-5.4.0-PSP.patch
@@ -1,0 +1,969 @@
+diff -Nru gcc-5.4.0/config.sub gcc-5.4.0-psp/config.sub
+--- gcc-5.4.0/config.sub	2013-10-01 17:50:56.000000000 +0100
++++ gcc-5.4.0-psp/config.sub	2015-10-19 00:17:27.020646514 +0100
+@@ -289,6 +289,7 @@
+ 	| mipsisa64sr71k | mipsisa64sr71kel \
+ 	| mipsr5900 | mipsr5900el \
+ 	| mipstx39 | mipstx39el \
++	| mipsallegrex | mipsallegrexel \
+ 	| mn10200 | mn10300 \
+ 	| moxie \
+ 	| mt \
+@@ -408,6 +409,7 @@
+ 	| mipsisa64sr71k-* | mipsisa64sr71kel-* \
+ 	| mipsr5900-* | mipsr5900el-* \
+ 	| mipstx39-* | mipstx39el-* \
++	| mipsallegrex-* | mipsallegrexel-* \
+ 	| mmix-* \
+ 	| mt-* \
+ 	| msp430-* \
+@@ -810,6 +812,10 @@
+ 		basic_machine=m68k-atari
+ 		os=-mint
+ 		;;
++	psp)
++		basic_machine=mipsallegrexel-psp
++		os=-elf
++		;;
+ 	mips3*-*)
+ 		basic_machine=`echo $basic_machine | sed -e 's/mips3/mips64/'`
+ 		;;
+diff -Nru gcc-5.4.0/gcc/config/mips/allegrex.md gcc-5.4.0-psp/gcc/config/mips/allegrex.md
+--- gcc-5.4.0/gcc/config/mips/allegrex.md	1970-01-01 01:00:00.000000000 +0100
++++ gcc-5.4.0-psp/gcc/config/mips/allegrex.md	2015-10-19 00:17:27.020646514 +0100
+@@ -0,0 +1,172 @@
++;; Sony ALLEGREX instructions.
++;; Copyright (C) 2005 Free Software Foundation, Inc.
++;;
++;; This file is part of GCC.
++;;
++;; GCC is free software; you can redistribute it and/or modify
++;; it under the terms of the GNU General Public License as published by
++;; the Free Software Foundation; either version 2, or (at your option)
++;; any later version.
++;;
++;; GCC is distributed in the hope that it will be useful,
++;; but WITHOUT ANY WARRANTY; without even the implied warranty of
++;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++;; GNU General Public License for more details.
++;;
++;; You should have received a copy of the GNU General Public License
++;; along with GCC; see the file COPYING.  If not, write to
++;; the Free Software Foundation, 59 Temple Place - Suite 330,
++;; Boston, MA 02111-1307, USA.
++
++(define_c_enum "unspec" [
++  UNSPEC_CLO
++  UNSPEC_CTO
++  UNSPEC_CACHE
++  UNSPEC_CEIL_W_S
++  UNSPEC_FLOOR_W_S
++  UNSPEC_ROUND_W_S
++])
++
++;; Multiply Add and Subtract.
++;; Note: removed clobbering for madd and msub (testing needed)
++
++(define_insn "allegrex_madd"
++  [(set (match_operand:SI 0 "register_operand" "+l")
++       (plus:SI (mult:SI (match_operand:SI 1 "register_operand" "d")
++             (match_operand:SI 2 "register_operand" "d"))
++        (match_dup 0)))]
++  "TARGET_ALLEGREX"
++  "madd\t%1,%2"
++  [(set_attr "type"    "imadd")
++   (set_attr "mode"    "SI")])
++
++(define_insn "allegrex_msub"
++  [(set (match_operand:SI 0 "register_operand" "+l")
++       (minus:SI (match_dup 0)
++         (mult:SI (match_operand:SI 1 "register_operand" "d")
++              (match_operand:SI 2 "register_operand" "d"))))]
++  "TARGET_ALLEGREX"
++  "msub\t%1,%2"
++  [(set_attr "type"    "imadd")
++   (set_attr "mode"    "SI")])
++
++
++;; Min and max.
++
++(define_insn "sminsi3"
++  [(set (match_operand:SI 0 "register_operand" "=d")
++        (smin:SI (match_operand:SI 1 "register_operand" "d")
++                 (match_operand:SI 2 "register_operand" "d")))]
++  "TARGET_ALLEGREX"
++  "min\t%0,%1,%2"
++  [(set_attr "type"    "arith")
++   (set_attr "mode"    "SI")])
++
++(define_insn "smaxsi3"
++  [(set (match_operand:SI 0 "register_operand" "=d")
++        (smax:SI (match_operand:SI 1 "register_operand" "d")
++                 (match_operand:SI 2 "register_operand" "d")))]
++  "TARGET_ALLEGREX"
++  "max\t%0,%1,%2"
++  [(set_attr "type"    "arith")
++   (set_attr "mode"    "SI")])
++
++
++;; Extended shift instructions.
++
++(define_insn "allegrex_bitrev"
++  [(set (match_operand:SI 0 "register_operand" "=d")
++   (unspec:SI [(match_operand:SI 1 "register_operand" "d")]
++          UNSPEC_BITREV))]
++  "TARGET_ALLEGREX"
++  "bitrev\t%0,%1"
++  [(set_attr "type"    "arith")
++   (set_attr "mode"    "SI")])
++
++;; Count leading ones, count trailing zeros, and count trailing ones (clz is
++;; already defined).
++
++(define_insn "allegrex_clo"
++  [(set (match_operand:SI 0 "register_operand" "=d")
++       (unspec:SI [(match_operand:SI 1 "register_operand" "d")]
++          UNSPEC_CLO))]
++  "TARGET_ALLEGREX"
++  "clo\t%0,%1"
++  [(set_attr "type"    "clz")
++   (set_attr "mode"    "SI")])
++
++(define_expand "ctzsi2"
++  [(set (match_operand:SI 0 "register_operand")
++       (ctz:SI (match_operand:SI 1 "register_operand")))]
++  "TARGET_ALLEGREX"
++{
++  rtx r1;
++
++  r1 = gen_reg_rtx (SImode);
++  emit_insn (gen_allegrex_bitrev (r1, operands[1]));
++  emit_insn (gen_clzsi2 (operands[0], r1));
++  DONE;
++})
++
++(define_expand "allegrex_cto"
++  [(set (match_operand:SI 0 "register_operand")
++       (unspec:SI [(match_operand:SI 1 "register_operand")]
++          UNSPEC_CTO))]
++  "TARGET_ALLEGREX"
++{
++  rtx r1;
++
++  r1 = gen_reg_rtx (SImode);
++  emit_insn (gen_allegrex_bitrev (r1, operands[1]));
++  emit_insn (gen_allegrex_clo (operands[0], r1));
++  DONE;
++})
++
++
++;; Misc.
++
++(define_insn "allegrex_sync"
++  [(unspec_volatile [(const_int 0)] UNSPEC_SYNC)]
++  "TARGET_ALLEGREX"
++  "sync"
++  [(set_attr "type"    "unknown")
++   (set_attr "mode"    "none")])
++
++(define_insn "allegrex_cache"
++  [(unspec_volatile [(match_operand:SI 0 "const_int_operand" "")
++            (match_operand:SI 1 "register_operand" "d")]
++           UNSPEC_CACHE)]
++  "TARGET_ALLEGREX"
++  "cache\t%0,0(%1)"
++  [(set_attr "type"    "unknown")
++   (set_attr "mode"    "none")])
++
++
++;; Floating-point builtins.
++
++(define_insn "allegrex_ceil_w_s"
++  [(set (match_operand:SI 0 "register_operand" "=f")
++       (unspec:SI [(match_operand:SF 1 "register_operand" "f")]
++          UNSPEC_CEIL_W_S))]
++  "TARGET_ALLEGREX"
++  "ceil.w.s\t%0,%1"
++  [(set_attr "type"    "fcvt")
++   (set_attr "mode"    "SF")])
++
++(define_insn "allegrex_floor_w_s"
++  [(set (match_operand:SI 0 "register_operand" "=f")
++       (unspec:SI [(match_operand:SF 1 "register_operand" "f")]
++          UNSPEC_FLOOR_W_S))]
++  "TARGET_ALLEGREX"
++  "floor.w.s\t%0,%1"
++  [(set_attr "type"    "fcvt")
++   (set_attr "mode"    "SF")])
++
++(define_insn "allegrex_round_w_s"
++  [(set (match_operand:SI 0 "register_operand" "=f")
++       (unspec:SI [(match_operand:SF 1 "register_operand" "f")]
++          UNSPEC_ROUND_W_S))]
++  "TARGET_ALLEGREX"
++  "round.w.s\t%0,%1"
++  [(set_attr "type"    "fcvt")
++   (set_attr "mode"    "SF")])
+diff -Nru gcc-5.4.0/gcc/config/mips/mips.c gcc-5.4.0-psp/gcc/config/mips/mips.c
+--- gcc-5.4.0/gcc/config/mips/mips.c	2014-03-08 09:27:23.000000000 +0000
++++ gcc-5.4.0-psp/gcc/config/mips/mips.c	2015-10-19 00:27:43.682089841 +0100
+@@ -248,7 +248,12 @@
+   MIPS_BUILTIN_CMP_SINGLE,
+ 
+   /* For generating bposge32 branch instructions in MIPS32 DSP ASE.  */
+-  MIPS_BUILTIN_BPOSGE32
++  MIPS_BUILTIN_BPOSGE32,
++
++  /* The builtin corresponds to the ALLEGREX cache instruction.  Operand 0
++     is the function code (must be less than 32) and operand 1 is the base
++     address.  */
++  MIPS_BUILTIN_CACHE
+ };
+ 
+ /* Invoke MACRO (COND) for each C.cond.fmt condition.  */
+@@ -574,6 +579,10 @@
+    normal branch.  */
+ static bool mips_branch_likely;
+ 
++/* Preferred stack boundary for proper stack vars alignment */
++unsigned int mips_preferred_stack_boundary;
++unsigned int mips_preferred_stack_align;
++
+ /* The current instruction-set architecture.  */
+ enum processor mips_arch;
+ const struct mips_cpu_info *mips_arch_info;
+@@ -919,6 +928,9 @@
+ 		     1,           /* branch_cost */
+ 		     4            /* memory_latency */
+   },
++  { /* Allegrex */
++    DEFAULT_COSTS
++  },
+   { /* Loongson-2E */
+     DEFAULT_COSTS
+   },
+@@ -13780,6 +13792,7 @@
+ AVAIL_NON_MIPS16 (dspr2_32, !TARGET_64BIT && TARGET_DSPR2)
+ AVAIL_NON_MIPS16 (loongson, TARGET_LOONGSON_VECTORS)
+ AVAIL_NON_MIPS16 (cache, TARGET_CACHE_BUILTIN)
++AVAIL_NON_MIPS16 (allegrex, TARGET_ALLEGREX)
+ 
+ /* Construct a mips_builtin_description from the given arguments.
+ 
+@@ -13876,6 +13889,30 @@
+   MIPS_BUILTIN (bposge, f, "bposge" #VALUE,				\
+ 		MIPS_BUILTIN_BPOSGE ## VALUE, MIPS_SI_FTYPE_VOID, AVAIL)
+ 
++/* Define a MIPS_BUILTIN_DIRECT function for instruction CODE_FOR_allegrex_<INSN>.
++   FUNCTION_TYPE and TARGET_FLAGS are builtin_description fields.  */
++#define DIRECT_ALLEGREX_BUILTIN(INSN, FUNCTION_TYPE, TARGET_FLAGS) \
++  { CODE_FOR_allegrex_ ## INSN, MIPS_FP_COND_f, "__builtin_allegrex_" #INSN,        \
++    MIPS_BUILTIN_DIRECT, FUNCTION_TYPE, mips_builtin_avail_allegrex }
++
++/* Same as the above, but mapped to an instruction that doesn't share the
++   NAME.  NAME is the name of the builtin without the builtin prefix.  */
++#define DIRECT_ALLEGREX_NAMED_BUILTIN(NAME, INSN, FUNCTION_TYPE, TARGET_FLAGS) \
++  { CODE_FOR_ ## INSN, MIPS_FP_COND_f, "__builtin_allegrex_" #NAME,             \
++    MIPS_BUILTIN_DIRECT, FUNCTION_TYPE, mips_builtin_avail_allegrex }
++
++/* Define a MIPS_BUILTIN_DIRECT_NO_TARGET function for instruction
++   CODE_FOR_allegrex_<INSN>.  FUNCTION_TYPE and TARGET_FLAGS are
++   builtin_description fields.  */
++#define DIRECT_ALLEGREX_NO_TARGET_BUILTIN(INSN, FUNCTION_TYPE, TARGET_FLAGS)   \
++  { CODE_FOR_allegrex_ ## INSN, MIPS_FP_COND_f, "__builtin_allegrex_" #INSN,            \
++    MIPS_BUILTIN_DIRECT_NO_TARGET, FUNCTION_TYPE, mips_builtin_avail_allegrex }
++
++/* Define a builtin with a specific function TYPE.  */
++#define SPECIAL_ALLEGREX_BUILTIN(TYPE, INSN, FUNCTION_TYPE, TARGET_FLAGS)  \
++  { CODE_FOR_allegrex_ ## INSN, MIPS_FP_COND_f, "__builtin_allegrex_" #INSN,            \
++    MIPS_BUILTIN_ ## TYPE, FUNCTION_TYPE, mips_builtin_avail_allegrex }
++
+ /* Define a Loongson MIPS_BUILTIN_DIRECT function __builtin_loongson_<FN_NAME>
+    for instruction CODE_FOR_loongson_<INSN>.  FUNCTION_TYPE is a
+    builtin_description field.  */
+@@ -14122,6 +14159,38 @@
+   DIRECT_BUILTIN (dpsqx_s_w_ph, MIPS_DI_FTYPE_DI_V2HI_V2HI, dspr2_32),
+   DIRECT_BUILTIN (dpsqx_sa_w_ph, MIPS_DI_FTYPE_DI_V2HI_V2HI, dspr2_32),
+ 
++/* Builtin functions for the Sony ALLEGREX processor.
++
++   These have the `__builtin_allegrex_' prefix instead of `__builtin_mips_'
++   to maintain compatibility with Sony's ALLEGREX GCC port.
++
++   Some of the builtins may seem redundant, but they are the same as the
++   builtins defined in the Sony compiler.  I chose to map redundant and
++   trivial builtins to the original instruction instead of creating
++   duplicate patterns specifically for the ALLEGREX (as Sony does).  */
++
++  DIRECT_ALLEGREX_BUILTIN(bitrev, MIPS_SI_FTYPE_SI, 0),
++  DIRECT_ALLEGREX_NAMED_BUILTIN(clz, clzsi2, MIPS_SI_FTYPE_SI, 0),
++  DIRECT_ALLEGREX_BUILTIN(clo, MIPS_SI_FTYPE_SI, 0),
++  DIRECT_ALLEGREX_NAMED_BUILTIN(ctz, ctzsi2, MIPS_SI_FTYPE_SI, 0),
++  DIRECT_ALLEGREX_BUILTIN(cto, MIPS_SI_FTYPE_SI, 0),
++  DIRECT_ALLEGREX_NAMED_BUILTIN(rotr, rotrsi3, MIPS_SI_FTYPE_SI_SI, 0),
++  DIRECT_ALLEGREX_NAMED_BUILTIN(rotl, rotlsi3, MIPS_SI_FTYPE_SI_SI, 0),
++
++  DIRECT_ALLEGREX_NAMED_BUILTIN(seb, extendqisi2, MIPS_SI_FTYPE_QI, 0),
++  DIRECT_ALLEGREX_NAMED_BUILTIN(seh, extendhisi2, MIPS_SI_FTYPE_HI, 0),
++  DIRECT_ALLEGREX_NAMED_BUILTIN(max, smaxsi3, MIPS_SI_FTYPE_SI_SI, 0),
++  DIRECT_ALLEGREX_NAMED_BUILTIN(min, sminsi3, MIPS_SI_FTYPE_SI_SI, 0),
++
++  DIRECT_ALLEGREX_NO_TARGET_BUILTIN(sync, MIPS_VOID_FTYPE_VOID, 0),
++  SPECIAL_ALLEGREX_BUILTIN(CACHE, cache, MIPS_VOID_FTYPE_SI_SI, 0),
++
++  DIRECT_ALLEGREX_NAMED_BUILTIN(sqrt_s, sqrtsf2, MIPS_SF_FTYPE_SF, 0),
++  DIRECT_ALLEGREX_BUILTIN(ceil_w_s, MIPS_SI_FTYPE_SF, 0),
++  DIRECT_ALLEGREX_BUILTIN(floor_w_s, MIPS_SI_FTYPE_SF, 0),
++  DIRECT_ALLEGREX_BUILTIN(round_w_s, MIPS_SI_FTYPE_SF, 0),
++  DIRECT_ALLEGREX_NAMED_BUILTIN(trunc_w_s, fix_truncsfsi2_insn, MIPS_SI_FTYPE_SF, 0),
++
+   /* Builtin functions for ST Microelectronics Loongson-2E/2F cores.  */
+   LOONGSON_BUILTIN (packsswh, MIPS_V4HI_FTYPE_V2SI_V2SI),
+   LOONGSON_BUILTIN (packsshb, MIPS_V8QI_FTYPE_V4HI_V4HI),
+@@ -14273,6 +14342,8 @@
+ /* Standard mode-based argument types.  */
+ #define MIPS_ATYPE_UQI unsigned_intQI_type_node
+ #define MIPS_ATYPE_SI intSI_type_node
++#define MIPS_ATYPE_HI intHI_type_node
++#define MIPS_ATYPE_QI intQI_type_node
+ #define MIPS_ATYPE_USI unsigned_intSI_type_node
+ #define MIPS_ATYPE_DI intDI_type_node
+ #define MIPS_ATYPE_UDI unsigned_intDI_type_node
+@@ -14575,6 +14646,26 @@
+ 				       const1_rtx, const0_rtx);
+ }
+ 
++/* Expand a __builtin_allegrex_cache() function.  Make sure the passed
++   cache function code is less than 32.  */
++
++static rtx
++mips_expand_builtin_cache (enum insn_code icode, rtx target, tree exp)
++{
++  int argno;
++  struct expand_operand ops[2];
++
++  for (argno = 0; argno < 2; argno++)
++    mips_prepare_builtin_arg (&ops[argno], exp, argno);
++
++  if (GET_CODE(ops[0].value) != CONST_INT ||
++      INTVAL(ops[0].value) < 0 || INTVAL(ops[0].value) > 0x1f)
++    error("Invalid first argument for cache builtin (0 <= arg <= 31)");
++
++  emit_insn(mips_expand_builtin_insn (icode, 2, ops, false));
++  return target;
++}
++
+ /* Implement TARGET_EXPAND_BUILTIN.  */
+ 
+ static rtx
+@@ -14620,6 +14711,9 @@
+ 
+     case MIPS_BUILTIN_BPOSGE32:
+       return mips_expand_builtin_bposge (d->builtin_type, target);
++
++    case MIPS_BUILTIN_CACHE:
++      return mips_expand_builtin_cache (d->icode, target, exp);
+     }
+   gcc_unreachable ();
+ }
+@@ -17376,6 +17470,22 @@
+ 
+   if (TARGET_HARD_FLOAT_ABI && TARGET_MIPS5900)
+     REAL_MODE_FORMAT (SFmode) = &spu_single_format;
++
++  /* Validate -mpreferred-stack-boundary= value, or provide default.
++     The default of 128-bit is for newABI else 64-bit.  */
++  mips_preferred_stack_boundary = (TARGET_NEWABI ? 128 : 64);
++  mips_preferred_stack_align = (TARGET_NEWABI ? 16 : 8);
++  if (mips_preferred_stack_boundary_string)
++    {
++      i = atoi (mips_preferred_stack_boundary_string);
++      if (i < 2 || i > 12)
++       error ("-mpreferred-stack-boundary=%d is not between 2 and 12", i);
++      else
++        {
++          mips_preferred_stack_align = (1 << i);
++          mips_preferred_stack_boundary = mips_preferred_stack_align * 8;
++        }
++    }
+ }
+ 
+ /* Swap the register information for registers I and I + 1, which
+diff -Nru gcc-5.4.0/gcc/config/mips/mips-cpus.def gcc-5.4.0-psp/gcc/config/mips/mips-cpus.def
+--- gcc-5.4.0/gcc/config/mips/mips-cpus.def	2014-03-04 21:39:50.000000000 +0000
++++ gcc-5.4.0-psp/gcc/config/mips/mips-cpus.def	2015-10-19 00:17:27.022646519 +0100
+@@ -55,6 +55,7 @@
+ 
+ /* MIPS II processors.  */
+ MIPS_CPU ("r6000", PROCESSOR_R6000, 2, 0)
++MIPS_CPU ("allegrex", PROCESSOR_ALLEGREX, 2, 0)
+ 
+ /* MIPS III processors.  */
+ MIPS_CPU ("r4000", PROCESSOR_R4000, 3, 0)
+diff -Nru gcc-5.4.0/gcc/config/mips/mips-ftypes.def gcc-5.4.0-psp/gcc/config/mips/mips-ftypes.def
+--- gcc-5.4.0/gcc/config/mips/mips-ftypes.def	2014-02-02 16:05:09.000000000 +0000
++++ gcc-5.4.0-psp/gcc/config/mips/mips-ftypes.def	2015-10-19 00:17:27.023646521 +0100
+@@ -53,9 +53,12 @@
+ DEF_MIPS_FTYPE (2, (SI, DI, SI))
+ DEF_MIPS_FTYPE (2, (SI, POINTER, SI))
+ DEF_MIPS_FTYPE (2, (DI, POINTER, SI))
++DEF_MIPS_FTYPE (1, (SI, HI))
++DEF_MIPS_FTYPE (1, (SI, SF))
+ DEF_MIPS_FTYPE (1, (SI, SI))
+ DEF_MIPS_FTYPE (2, (SI, SI, SI))
+ DEF_MIPS_FTYPE (3, (SI, SI, SI, SI))
++DEF_MIPS_FTYPE (1, (SI, QI))
+ DEF_MIPS_FTYPE (1, (SI, V2HI))
+ DEF_MIPS_FTYPE (2, (SI, V2HI, V2HI))
+ DEF_MIPS_FTYPE (1, (SI, V4QI))
+@@ -127,3 +130,4 @@
+ DEF_MIPS_FTYPE (1, (VOID, USI))
+ DEF_MIPS_FTYPE (2, (VOID, V2HI, V2HI))
+ DEF_MIPS_FTYPE (2, (VOID, V4QI, V4QI))
++DEF_MIPS_FTYPE (1, (VOID, VOID))
+diff -Nru gcc-5.4.0/gcc/config/mips/mips.h gcc-5.4.0-psp/gcc/config/mips/mips.h
+--- gcc-5.4.0/gcc/config/mips/mips.h	2015-02-26 10:40:06.000000000 +0000
++++ gcc-5.4.0-psp/gcc/config/mips/mips.h	2015-10-19 00:23:37.066514436 +0100
+@@ -231,6 +231,7 @@
+ #define TARGET_SB1                  (mips_arch == PROCESSOR_SB1		\
+ 				     || mips_arch == PROCESSOR_SB1A)
+ #define TARGET_SR71K                (mips_arch == PROCESSOR_SR71000)
++#define TARGET_ALLEGREX             (mips_arch == PROCESSOR_ALLEGREX)
+ #define TARGET_XLP                  (mips_arch == PROCESSOR_XLP)
+ 
+ /* Scheduling target defines.  */
+@@ -260,6 +261,7 @@
+ #define TUNE_SB1                    (mips_tune == PROCESSOR_SB1		\
+ 				     || mips_tune == PROCESSOR_SB1A)
+ #define TUNE_P5600                  (mips_tune == PROCESSOR_P5600)
++#define TUNE_ALLEGREX               (mips_tune == PROCESSOR_ALLEGREX)
+ 
+ /* Whether vector modes and intrinsics for ST Microelectronics
+    Loongson-2E/2F processors should be enabled.  In o32 pairs of
+@@ -868,6 +870,9 @@
+ 				 && !TARGET_MIPS5900			\
+ 				 && !TARGET_MIPS16)
+ 
++/* ISA has just the integer condition move instructions (movn,movz) */
++#define ISA_HAS_INT_CONDMOVE   (TARGET_ALLEGREX)
++
+ /* ISA has the mips4 FP condition code instructions: FP-compare to CC,
+    branch on CC, and move (both FP and non-FP) on CC.  */
+ #define ISA_HAS_8CC		(ISA_MIPS4				\
+@@ -895,6 +900,7 @@
+ 
+ /* ISA has conditional trap instructions.  */
+ #define ISA_HAS_COND_TRAP	(!ISA_MIPS1				\
++				 && !TARGET_ALLEGREX				\
+ 				 && !TARGET_MIPS16)
+ 
+ /* ISA has integer multiply-accumulate instructions, madd and msub.  */
+@@ -910,6 +916,6 @@
+ #define ISA_HAS_IEEE_754_2008	(mips_isa_rev >= 2)
+
+ /* ISA has count leading zeroes/ones instruction (not implemented).  */
+-#define ISA_HAS_CLZ_CLO		(mips_isa_rev >= 1 && !TARGET_MIPS16)
++#define ISA_HAS_CLZ_CLO		((mips_isa_rev >= 1 && !TARGET_MIPS16) || TARGET_ALLEGREX)
+
+ /* ISA has three operand multiply instructions that put
+    the high part in an accumulator: mulhi or mulhiu.  */
+@@ -983,6 +990,7 @@
+ 				  || TARGET_MIPS5400			\
+ 				  || TARGET_MIPS5500			\
+ 				  || TARGET_SR71K			\
++				  || TARGET_ALLEGREX			\
+ 				  || TARGET_SMARTMIPS)			\
+ 				 && !TARGET_MIPS16)
+ 
+@@ -1014,11 +1022,13 @@
+ #define ISA_HAS_TRUNC_W		(!ISA_MIPS1)
+
+ /* ISA includes the MIPS32r2 seb and seh instructions.  */
+-#define ISA_HAS_SEB_SEH		(mips_isa_rev >= 2 && !TARGET_MIPS16)
++#define ISA_HAS_SEB_SEH		((mips_isa_rev >= 2 && !TARGET_MIPS16) || TARGET_ALLEGREX)
+
+ /* ISA includes the MIPS32/64 rev 2 ext and ins instructions.  */
+-#define ISA_HAS_EXT_INS		(mips_isa_rev >= 2 && !TARGET_MIPS16)
++#define ISA_HAS_EXT_INS		((mips_isa_rev >= 2 && !TARGET_MIPS16) || TARGET_ALLEGREX)
+
+ /* ISA has instructions for accessing top part of 64-bit fp regs.  */
+ #define ISA_HAS_MXHC1		(!TARGET_FLOAT32	\
+@@ -1084,7 +1094,8 @@
+ 				 || ISA_MIPS64R2			\
+ 				 || TARGET_MIPS5500			\
+ 				 || TARGET_MIPS5900			\
+-				 || TARGET_LOONGSON_2EF)
++				 || TARGET_LOONGSON_2EF		\
++				 || TARGET_ALLEGREX)
+ 
+ /* ISA includes synci, jr.hb and jalr.hb.  */
+ #define ISA_HAS_SYNCI ((ISA_MIPS32R2		\
+@@ -2209,7 +2220,7 @@
+    `crtl->outgoing_args_size'.  */
+ #define OUTGOING_REG_PARM_STACK_SPACE(FNTYPE) 1
+ 
+-#define STACK_BOUNDARY (TARGET_NEWABI ? 128 : 64)
++#define STACK_BOUNDARY (mips_preferred_stack_boundary)
+ 
+ /* Symbolic macros for the registers used to return integer and floating
+    point values.  */
+@@ -2321,7 +2332,7 @@
+ /* Treat LOC as a byte offset from the stack pointer and round it up
+    to the next fully-aligned offset.  */
+ #define MIPS_STACK_ALIGN(LOC) \
+-  (TARGET_NEWABI ? ((LOC) + 15) & -16 : ((LOC) + 7) & -8)
++  (((LOC) + (mips_preferred_stack_align - 1)) & -(mips_preferred_stack_align))
+ 
+ 
+ /* Output assembler code to FILE to increment profiler label # LABELNO
+@@ -2937,6 +2948,9 @@
+ 	" TEXT_SECTION_ASM_OP);
+ #endif
+ 
++extern unsigned int mips_preferred_stack_boundary;
++extern unsigned int mips_preferred_stack_align;
++
+ #ifndef HAVE_AS_TLS
+ #define HAVE_AS_TLS 0
+ #endif
+diff -Nru gcc-5.4.0/gcc/config/mips/mips.md gcc-5.4.0-psp/gcc/config/mips/mips.md
+--- gcc-5.4.0/gcc/config/mips/mips.md	2014-02-02 16:05:09.000000000 +0000
++++ gcc-5.4.0-psp/gcc/config/mips/mips.md	2015-10-19 00:22:37.694375908 +0100
+@@ -35,6 +35,7 @@
+   74kf2_1
+   74kf1_1
+   74kf3_2
++  allegrex
+   loongson_2e
+   loongson_2f
+   loongson_3a
+@@ -756,6 +757,7 @@
+ (define_mode_iterator MOVECC [SI (DI "TARGET_64BIT")
+                               (CC "TARGET_HARD_FLOAT
+ 				   && !TARGET_LOONGSON_2EF
++				   && !TARGET_ALLEGREX
+ 				   && !TARGET_MIPS5900")])
+ 
+ ;; 32-bit integer moves for which we provide move patterns.
+@@ -2070,11 +2072,11 @@
+ 	   (mult:DI
+ 	      (any_extend:DI (match_operand:SI 1 "register_operand" "d"))
+ 	      (any_extend:DI (match_operand:SI 2 "register_operand" "d")))))]
+-  "!TARGET_64BIT && (ISA_HAS_MSAC || GENERATE_MADD_MSUB || ISA_HAS_DSP)"
++  "!TARGET_64BIT && (ISA_HAS_MSAC || GENERATE_MADD_MSUB || ISA_HAS_DSP || TARGET_ALLEGREX)"
+ {
+   if (ISA_HAS_DSP_MULT)
+     return "msub<u>\t%q0,%1,%2";
+-  else if (TARGET_MIPS5500 || GENERATE_MADD_MSUB)
++  else if (TARGET_MIPS5500 || GENERATE_MADD_MSUB || TARGET_ALLEGREX)
+     return "msub<u>\t%1,%2";
+   else
+     return "msac<u>\t$0,%1,%2";
+@@ -2312,14 +2314,14 @@
+ 	 (mult:DI (any_extend:DI (match_operand:SI 1 "register_operand" "d"))
+ 		  (any_extend:DI (match_operand:SI 2 "register_operand" "d")))
+ 	 (match_operand:DI 3 "muldiv_target_operand" "0")))]
+-  "(TARGET_MAD || ISA_HAS_MACC || GENERATE_MADD_MSUB || ISA_HAS_DSP)
++  "(TARGET_MAD || ISA_HAS_MACC || GENERATE_MADD_MSUB || ISA_HAS_DSP || TARGET_ALLEGREX)
+    && !TARGET_64BIT"
+ {
+   if (TARGET_MAD)
+     return "mad<u>\t%1,%2";
+   else if (ISA_HAS_DSP_MULT)
+     return "madd<u>\t%q0,%1,%2";
+-  else if (GENERATE_MADD_MSUB || TARGET_MIPS5500)
++  else if (GENERATE_MADD_MSUB || TARGET_MIPS5500 || TARGET_ALLEGREX)
+     return "madd<u>\t%1,%2";
+   else
+     /* See comment in *macc.  */
+@@ -2857,6 +2859,33 @@
+ ;;
+ ;;  ....................
+ ;;
++;; FIND FIRST BIT INSTRUCTION
++;;
++;;  ....................
++;;
++
++(define_expand "ffs<mode>2"
++  [(set (match_operand:GPR 0 "register_operand" "")
++   (ffs:GPR (match_operand:GPR 1 "register_operand" "")))]
++  "ISA_HAS_CLZ_CLO"
++{
++  rtx r1, r2, r3, r4;
++  
++  r1 = gen_reg_rtx (<MODE>mode);
++  r2 = gen_reg_rtx (<MODE>mode);
++  r3 = gen_reg_rtx (<MODE>mode);
++  r4 = gen_reg_rtx (<MODE>mode);
++  emit_insn (gen_neg<mode>2 (r1, operands[1]));
++  emit_insn (gen_and<mode>3 (r2, operands[1], r1));
++  emit_insn (gen_clz<mode>2 (r3, r2));
++  emit_move_insn (r4, GEN_INT (GET_MODE_BITSIZE (<MODE>mode)));
++  emit_insn (gen_sub<mode>3 (operands[0], r4, r3));
++  DONE;
++})
++
++;;
++;;  ....................
++;;
+ ;;	NEGATION and ONE'S COMPLEMENT
+ ;;
+ ;;  ....................
+@@ -2909,6 +2938,25 @@
+    (set_attr "compression" "micromips,*")
+    (set_attr "mode" "<MODE>")])
+ 
++(define_expand "rotl<mode>3"
++  [(set (match_operand:GPR 0 "register_operand")
++       (rotate:GPR (match_operand:GPR 1 "register_operand")
++           (match_operand:SI 2 "arith_operand")))]
++  "ISA_HAS_ROR"
++{
++  rtx temp;
++
++  if (GET_CODE (operands[2]) == CONST_INT)
++    temp = GEN_INT (GET_MODE_BITSIZE (<MODE>mode) - INTVAL (operands[2]));
++  else
++    {
++      temp = gen_reg_rtx (<MODE>mode);
++      emit_insn (gen_neg<mode>2 (temp, operands[2]));
++    }
++  emit_insn (gen_rotr<mode>3 (operands[0], operands[1], temp));
++  DONE;
++})
++
+ ;;
+ ;;  ....................
+ ;;
+@@ -6869,7 +6917,7 @@
+ 		 (const_int 0)])
+ 	 (match_operand:GPR 2 "reg_or_0_operand" "dJ,0")
+ 	 (match_operand:GPR 3 "reg_or_0_operand" "0,dJ")))]
+-  "ISA_HAS_CONDMOVE"
++  "ISA_HAS_CONDMOVE || ISA_HAS_INT_CONDMOVE"
+   "@
+     mov%T4\t%0,%z2,%1
+     mov%t4\t%0,%z3,%1"
+@@ -7185,6 +7237,9 @@
+ ; ST-Microelectronics Loongson-2E/2F-specific patterns.
+ (include "loongson.md")
+ 
++; Sony ALLEGREX instructions.
++(include "allegrex.md")
++
+ (define_c_enum "unspec" [
+   UNSPEC_ADDRESS_FIRST
+ ])
+diff -Nru gcc-5.4.0/gcc/config/mips/mips.opt gcc-5.4.0-psp/gcc/config/mips/mips.opt
+--- gcc-5.4.0/gcc/config/mips/mips.opt	2014-02-21 13:30:47.000000000 +0000
++++ gcc-5.4.0-psp/gcc/config/mips/mips.opt	2015-10-19 00:17:27.025646526 +0100
+@@ -400,5 +400,9 @@
+ Target Report Var(TARGET_XGOT)
+ Lift restrictions on GOT size
+ 
++mpreferred-stack-boundary=
++Target RejectNegative Joined Var(mips_preferred_stack_boundary_string)
++Attempt to keep stack aligned to this power of 2
++
+ noasmopt
+ Driver
+diff -Nru gcc-5.4.0/gcc/config/mips/psp.h gcc-5.4.0-psp/gcc/config/mips/psp.h
+--- gcc-5.4.0/gcc/config/mips/psp.h	1970-01-01 01:00:00.000000000 +0100
++++ gcc-5.4.0-psp/gcc/config/mips/psp.h	2015-10-19 00:17:27.025646526 +0100
+@@ -0,0 +1,31 @@
++/* Support for Sony's Playstation Portable (PSP).
++   Copyright (C) 2005 Free Software Foundation, Inc.
++   Contributed by Marcus R. Brown <mrbrown@ocgnet.org>
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 2, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING.  If not, write to
++the Free Software Foundation, 59 Temple Place - Suite 330,
++Boston, MA 02111-1307, USA.  */
++
++/* Override the startfile spec to include crt0.o. */
++#undef STARTFILE_SPEC
++#define STARTFILE_SPEC "crt0%O%s crti%O%s crtbegin%O%s"
++
++#undef SUBTARGET_CPP_SPEC
++#define SUBTARGET_CPP_SPEC "-DPSP=1 -D__psp__=1 -D_PSP=1"
++
++/* Get rid of the .pdr section. */
++#undef SUBTARGET_ASM_SPEC
++#define SUBTARGET_ASM_SPEC "-mno-pdr"
+diff -Nru gcc-5.4.0/gcc/config/mips/t-allegrex gcc-5.4.0-psp/gcc/config/mips/t-allegrex
+--- gcc-5.4.0/gcc/config/mips/t-allegrex	1970-01-01 01:00:00.000000000 +0100
++++ gcc-5.4.0-psp/gcc/config/mips/t-allegrex	2015-10-19 00:17:27.025646526 +0100
+@@ -0,0 +1,29 @@
++# Suppress building libgcc1.a, since the MIPS compiler port is complete
++# and does not need anything from libgcc1.a.
++LIBGCC1 =
++CROSS_LIBGCC1 =
++
++EXTRA_MULTILIB_PARTS = crtbegin.o crtend.o crti.o crtn.o
++# Don't let CTOR_LIST end up in sdata section.
++CRTSTUFF_T_CFLAGS = -G 0
++
++# Assemble startup files.
++$(T)crti.o: $(srcdir)/config/mips/crti.asm $(GCC_PASSES)
++	$(GCC_FOR_TARGET) $(GCC_CFLAGS) $(MULTILIB_CFLAGS) $(INCLUDES) \
++	-c -o $(T)crti.o -x assembler-with-cpp $(srcdir)/config/mips/crti.asm
++
++$(T)crtn.o: $(srcdir)/config/mips/crtn.asm $(GCC_PASSES)
++	$(GCC_FOR_TARGET) $(GCC_CFLAGS) $(MULTILIB_CFLAGS) $(INCLUDES) \
++	-c -o $(T)crtn.o -x assembler-with-cpp $(srcdir)/config/mips/crtn.asm
++
++# We must build libgcc2.a with -G 0, in case the user wants to link
++# without the $gp register.
++TARGET_LIBGCC2_CFLAGS = -G 0
++
++# Build the libraries for both hard and soft floating point
++
++MULTILIB_OPTIONS = 
++MULTILIB_DIRNAMES = 
++
++LIBGCC = stmp-multilib
++INSTALL_LIBGCC = install-multilib
+diff -Nru gcc-5.4.0/gcc/config.gcc gcc-5.4.0-psp/gcc/config.gcc
+--- gcc-5.4.0/gcc/config.gcc	2015-05-21 21:50:59.000000000 +0100
++++ gcc-5.4.0-psp/gcc/config.gcc	2015-10-19 00:17:27.025646526 +0100
+@@ -2118,6 +2118,18 @@
+ 	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/r3900.h mips/elf.h"
+ 	tmake_file="mips/t-r3900"
+ 	;;
++mipsallegrex-*-elf* | mipsallegrexel-*-elf*)
++   tm_file="elfos.h ${tm_file} mips/elf.h"
++   tmake_file=mips/t-allegrex
++   target_cpu_default="MASK_SINGLE_FLOAT|MASK_DIVIDE_BREAKS"
++   tm_defines="MIPS_ISA_DEFAULT=2 MIPS_CPU_STRING_DEFAULT=\\\"allegrex\\\" MIPS_ABI_DEFAULT=ABI_EABI"
++   case ${target} in
++   mipsallegrex*-psp-elf*) 
++       tm_file="${tm_file} mips/psp.h"
++       ;;
++   esac
++   use_fixproto=yes
++   ;;
+ mmix-knuth-mmixware)
+ 	tm_file="${tm_file} newlib-stdint.h"
+ 	need_64bit_hwint=yes
+diff -Nru gcc-5.4.0/libcpp/Makefile.in gcc-5.4.0-psp/libcpp/Makefile.in
+--- gcc-5.4.0/libcpp/Makefile.in	2015-06-26 18:59:14.000000000 +0100
++++ gcc-5.4.0-psp/libcpp/Makefile.in	2015-10-19 00:17:27.026646529 +0100
+@@ -208,8 +208,8 @@
+ # Note that we put the dependencies into a .Tpo file, then move them
+ # into place if the compile succeeds.  We need this because gcc does
+ # not atomically write the dependency output file.
+-COMPILE = $(COMPILE.base) -o $@ -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Tpo
+-POSTCOMPILE = @mv $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Po
++COMPILE = $(COMPILE.base) -o $@
++POSTCOMPILE =
+ else
+ COMPILE = source='$<' object='$@' libtool=no DEPDIR=$(DEPDIR) $(DEPMODE) \
+ 	  $(depcomp) $(COMPILE.base)
+diff -Nru gcc-5.4.0/libgcc/config/mips/psp.h gcc-5.4.0-psp/libgcc/config/mips/psp.h
+--- gcc-5.4.0/libgcc/config/mips/psp.h	1970-01-01 01:00:00.000000000 +0100
++++ gcc-5.4.0-psp/libgcc/config/mips/psp.h	2015-10-19 00:17:27.026646529 +0100
+@@ -0,0 +1,31 @@
++/* Support for Sony's Playstation Portable (PSP).
++   Copyright (C) 2005 Free Software Foundation, Inc.
++   Contributed by Marcus R. Brown <mrbrown@ocgnet.org>
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 2, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING.  If not, write to
++the Free Software Foundation, 59 Temple Place - Suite 330,
++Boston, MA 02111-1307, USA.  */
++
++/* Override the startfile spec to include crt0.o. */
++#undef STARTFILE_SPEC
++#define STARTFILE_SPEC "crt0%O%s crti%O%s crtbegin%O%s"
++
++#undef SUBTARGET_CPP_SPEC
++#define SUBTARGET_CPP_SPEC "-DPSP=1 -D__psp__=1 -D_PSP=1"
++
++/* Get rid of the .pdr section. */
++#undef SUBTARGET_ASM_SPEC
++#define SUBTARGET_ASM_SPEC "-mno-pdr"
+diff -Nru gcc-5.4.0/libgcc/config/mips/t-allegrex gcc-5.4.0-psp/libgcc/config/mips/t-allegrex
+--- gcc-5.4.0/libgcc/config/mips/t-allegrex	1970-01-01 01:00:00.000000000 +0100
++++ gcc-5.4.0-psp/libgcc/config/mips/t-allegrex	2015-10-19 00:17:27.026646529 +0100
+@@ -0,0 +1,20 @@
++# Suppress building libgcc1.a, since the MIPS compiler port is complete
++# and does not need anything from libgcc1.a.
++LIBGCC1 =
++CROSS_LIBGCC1 =
++
++EXTRA_MULTILIB_PARTS = crtbegin.o crtend.o crti.o crtn.o
++# Don't let CTOR_LIST end up in sdata section.
++CRTSTUFF_T_CFLAGS = -G 0
++
++# We must build libgcc2.a with -G 0, in case the user wants to link
++# without the $gp register.
++TARGET_LIBGCC2_CFLAGS = -G 0
++
++# Build the libraries for both hard and soft floating point
++
++MULTILIB_OPTIONS = 
++MULTILIB_DIRNAMES = 
++
++LIBGCC = stmp-multilib
++INSTALL_LIBGCC = install-multilib
+diff -Nru gcc-5.4.0/libgcc/config.host gcc-5.4.0-psp/libgcc/config.host
+--- gcc-5.4.0/libgcc/config.host	2014-03-27 15:40:31.000000000 +0000
++++ gcc-5.4.0-psp/libgcc/config.host	2015-10-19 00:17:27.026646529 +0100
+@@ -140,11 +140,15 @@ microblaze*-*-*)
+ 	cpu_type=microblaze
+ 	;;
+ mips*-*-*)
+-	# All MIPS targets provide a full set of FP routines.
+ 	cpu_type=mips
+ 	tmake_file="mips/t-mips"
+ 	if test "${libgcc_cv_mips_hard_float}" = yes; then
+-		tmake_file="${tmake_file} t-hardfp-sfdf t-hardfp"
++		if test "${libgcc_cv_mips_single_float}" = yes; then
++			tmake_file="${tmake_file} t-hardfp-sf"
++		else
++			tmake_file="${tmake_file} t-hardfp-sfdf"
++		fi
++		tmake_file="${tmake_file} t-hardfp"
+ 	else
+ 		tmake_file="${tmake_file} t-softfp-sfdf"
+ 	fi
+@@ -860,6 +860,14 @@
+ mipstx39-*-elf* | mipstx39el-*-elf*)
+ 	tmake_file="$tmake_file mips/t-crtstuff mips/t-mips16"
+ 	;;
++mips*-psp*)
++    tmake_file="${tmake_file} mips/t-allegrex"
++    target_cpu_default="MASK_SINGLE_FLOAT|MASK_DIVIDE_BREAKS"
++    tm_file="${tm_file} mips/psp.h"
++	 extra_parts="$extra_parts crti.o crtn.o"
++    use_fixproto=yes
++    tm_defines="MIPS_ISA_DEFAULT=2 MIPS_CPU_STRING_DEFAULT=\\\"allegrex\\\" MIPS_ABI_DEFAULT=ABI_EABI"
++	;;
+ mmix-knuth-mmixware)
+ 	extra_parts="crti.o crtn.o crtbegin.o crtend.o"
+ 	tmake_file="${tmake_file} ${cpu_type}/t-${cpu_type}"
+diff -Nru gcc-5.4.0/libgcc/crtstuff.c gcc-5.4.0-psp/libgcc/crtstuff.c
+--- gcc-5.4.0/libgcc/crtstuff.c	2014-03-10 18:31:20.000000000 +0000
++++ gcc-5.4.0-psp/libgcc/crtstuff.c	2015-10-19 00:17:27.026646529 +0100
+@@ -47,7 +47,7 @@
+ 
+ /* Target machine header files require this define. */
+ #define IN_LIBGCC2
+-
++#define USED_FOR_TARGET
+ /* FIXME: Including auto-host is incorrect, but until we have
+    identified the set of defines that need to go into auto-target.h,
+    this will have to do.  */
+diff --git /dev/null gcc-5.4.0-psp/libgcc/config/t-hardfp-sf
+new file mode 100644
+index 00000000000..10682690219
+--- /dev/null
++++ gcc-5.4.0-psp/libgcc/config/t-hardfp-sf
+@@ -0,0 +1,32 @@
++# Copyright (C) 2014 Free Software Foundation, Inc.
++
++# This file is part of GCC.
++
++# GCC is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 3, or (at your option)
++# any later version.
++
++# GCC is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++
++# You should have received a copy of the GNU General Public License
++# along with GCC; see the file COPYING3.  If not see
++# <http://www.gnu.org/licenses/>.
++
++hardfp_float_modes := sf
++# di and ti are provided by libgcc2.c where needed.
++hardfp_int_modes := si
++hardfp_extensions := 
++hardfp_truncations := 
++
++# Emulate 64 bit float:
++FPBIT = true
++DPBIT = true
++# Don't build functions handled by 32 bit hardware:
++LIB2FUNCS_EXCLUDE = _addsub_sf _mul_sf _div_sf \
++    _fpcmp_parts_sf _compare_sf _eq_sf _ne_sf _gt_sf _ge_sf \
++    _lt_sf _le_sf _unord_sf _si_to_sf _sf_to_si _negate_sf \
++    _thenan_sf _sf_to_usi _usi_to_sf
+diff --git gcc-5.4.0/libgcc/configure gcc-5.4.0-psp/libgcc/configure
+index 35896deb7bf..b04e158e155 100644
+--- gcc-5.4.0/libgcc/configure
++++ gcc-5.4.0-psp/libgcc/configure
+@@ -4352,6 +4352,26 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_hard_float" >&5
+ $as_echo "$libgcc_cv_mips_hard_float" >&6; }
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the target is single-float" >&5
++$as_echo_n "checking whether the target is single-float... " >&6; }
++if test "${libgcc_cv_mips_single_float+set}" = set; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#ifndef __mips_single_float
++     #error FOO
++     #endif
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  libgcc_cv_mips_single_float=yes
++else
++  libgcc_cv_mips_single_float=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_single_float" >&5
++$as_echo "$libgcc_cv_mips_single_float" >&6; }
+ esac
+ 
+ # Collect host-machine-specific information.
+diff --git gcc-5.4.0/libgcc/configure.ac gcc-5.4.0-psp/libgcc/configure.ac
+index d877d21c092..312bf264679 100644
+--- gcc-5.4.0/libgcc/configure.ac
++++ gcc-5.4.0-psp/libgcc/configure.ac
+@@ -302,6 +302,14 @@ mips*-*-*)
+      #endif],
+     [libgcc_cv_mips_hard_float=yes],
+     [libgcc_cv_mips_hard_float=no])])
++  AC_CACHE_CHECK([whether the target is single-float],
++		 [libgcc_cv_mips_single_float],
++		 [AC_COMPILE_IFELSE(
++    [#ifndef __mips_single_float
++     #error FOO
++     #endif],
++    [libgcc_cv_mips_single_float=yes],
++    [libgcc_cv_mips_single_float=no])])
+ esac
+ 
+ # Collect host-machine-specific information.

--- a/patches/patch-gcc_cp_cfns.h
+++ b/patches/patch-gcc_cp_cfns.h
@@ -1,15 +1,5 @@
 --- gcc/cp/cfns.h.orig	2015-02-13 08:27:46.000000000 +0200
 +++ gcc/cp/cfns.h	2015-02-13 10:23:53.000000000 +0200
-@@ -53,6 +53,9 @@
- static unsigned int hash (const char *, unsigned int);
- #ifdef __GNUC__
- __inline
-+#ifdef __GNUC_STDC_INLINE__
-+__attribute__ ((__gnu_inline__))
-+#endif
- #endif
- const char * libc_name_p (const char *, unsigned int);
- /* maximum key range = 391, duplicates = 0 */
 @@ -96,7 +99,7 @@
        400, 400, 400, 400, 400, 400, 400, 400, 400, 400,
        400, 400, 400, 400, 400, 400, 400

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -2,7 +2,7 @@
 # gcc-stage1.sh by Dan Peori (danpeori@oopo.net) customized by yreeen(yreeen@gmail.com)
 
  ## set gcc version
- GCC_VERSION=4.9.3
+ GCC_VERSION=5.4.0
  GMP_VERSION=5.1.3
  MPC_VERSION=1.0.2
  MPFR_VERSION=3.1.2

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -3,7 +3,7 @@
 # gdc support from TurkeyMan( https://github.com/TurkeyMan )
 
  ## set gcc version
- GCC_VERSION=4.9.3
+ GCC_VERSION=5.4.0
  GMP_VERSION=5.1.3
  MPC_VERSION=1.0.2
  MPFR_VERSION=3.1.2


### PR DESCRIPTION
Some minor changes in mips.h to simplify ISA versions and revisions
requires a bit more care with allegrex, but should be all covered.
No compiler bugs found while building the toolchain, except for
openal frontend errors, probably time to update the library to a
newer version.