### PR TITLE
Don't check for sdl-config

### DIFF
--- a/depends/check-dependencies.sh
+++ b/depends/check-dependencies.sh
@@ -86,7 +86,6 @@ check_program   make
 check_program   gcc
 check_program   g++
 
-check_program   sdl-config
 # check_program   freetype-config
 
 check_program   bison


### PR DESCRIPTION
I had missed the the check-dependencies script checks for sdl-config. It seems I had tested this with top-sekret's repo, my bad. I'm doing another test run now, will update this PR once it's finished.