### PR TITLE
Add flags for MacPorts and Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ Ubuntu/Debian
 OSX
 ---
 
-1. Install [`port`][MacPorts] or [`brew`][HomeBrew].
+1. Install [`port`][MacPorts] or [`brew`][Homebrew].
 2. Install all the libraries you will need before building by running:
         
     sudo ./prepare-mac-os.sh
+- You can also use `-b` or `--brew` for Homebrew, and `-p` or `--port` for MacPorts.
 
 3. Build and install the toolchain and SDK.
         

--- a/prepare-mac-os.sh
+++ b/prepare-mac-os.sh
@@ -8,14 +8,27 @@ install_libusb() {
 	cd ../
 	rm -Rf libusb-legacy && rm libusb-legacy.tar.gz
 }
-
-if [ -e "/opt/local/bin/port" ]; then
-	sudo port install automake cmake doxygen libelf libusb wget xz
-	
-	install_libusb
-elif [ -e "/usr/local/bin/brew" ]; then
+brew() {
 	CURRENT_USER=$(stat -f '%Su' /dev/console)
-	sudo -u $CURRENT_USER brew install automake cmake doxygen libelf libusb libusb-compat wget xz
-else
-	echo "Go install MacPorts from http://www.macports.org/ or Homebrew from http://brew.sh/ first, then we can talk"
+	sudo -u $CURRENT_USER brew install brew install autoconf automake cmake doxygen gnu-sed libelf libool libusb libusb-compat pkg-config wget xz
+}
+ports() {
+	sudo port install autoconf automake cmake doxygen gsed libelf libtool libusb pkgconfig wget xz
+	install_libusb
+}
+
+if [ "$1" == "-b" ] || [ "$1" == "--brew" ]; then # Homebrew flag
+	brew()
+elif [ "$1" == "-p" ] || [ "$1" == "--port" ]; then # MacPorts flag
+	ports()
+elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then # Help
+	echo "Use '-b' or '--brew' to install packages with Homebrew, or use '-p' or '--port' to install with MacPorts."
+else # no flag
+	if [ -e "/usr/local/bin/brew" ]; then
+		brew()
+	elif [ -e "/opt/local/bin/port" ]; then
+		ports()
+	else
+		echo "Go install MacPorts from http://www.macports.org/ or Homebrew from http://brew.sh/ first, then we can talk"
+	fi
 fi


### PR DESCRIPTION
Added `-b`, `--brew`, `-p`, `--port`, `-h`, and `--help` for people who have both Homebrew and MacPorts installed. Also rearranges the order so if no flags are given it checks for Homebrew first.