### PR TITLE
Add prepare script for fedora

### DIFF
--- a/prepare-fedora.sh
+++ b/prepare-fedora.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Install build dependencies
+sudo dnf install $@ \
+  autoconf automake bison bzip2 cmake doxygen diffutils flex g++ gcc git \
+  gzip libarchive-devel libcurl-devel elfutils-libelf-devel gpgme-devel \
+  openssl-devel libtool libusb-devel m4 make ncurses-devel patch pkgconf \
+  python3 readline-devel subversion tar tcl texinfo unzip which wget xz


### PR DESCRIPTION
I've tested this in the fedora:latest docker container from the Dockerhub. The toolchain builds like expected after running it.