### PR TITLE
Add support for aarch64

### DIFF
--- a/patches/binutils-2.23.2-PSP.patch
+++ b/patches/binutils-2.23.2-PSP.patch
@@ -151,6 +151,50 @@ diff -NrU3 binutils-2.23.2/config.sub binutils-2.23.2-patched/config.sub
  	mips3*-*)
  		basic_machine=`echo $basic_machine | sed -e 's/mips3/mips64/'`
  		;;
+--- binutils-2.23.2/config.guess	2021-02-14 16:35:28.201894642 +0800
++++ binutils-2.23.2-patched/config.guess	2021-02-14 16:36:42.841894677 +0800
+@@ -140,6 +140,27 @@
+ UNAME_SYSTEM=`(uname -s) 2>/dev/null`  || UNAME_SYSTEM=unknown
+ UNAME_VERSION=`(uname -v) 2>/dev/null` || UNAME_VERSION=unknown
+ 
++case "${UNAME_SYSTEM}" in
++Linux|GNU|GNU/*)
++	# If the system lacks a compiler, then just pick glibc.
++	# We could probably try harder.
++	LIBC=gnu
++
++	eval $set_cc_for_build
++	cat <<-EOF > $dummy.c
++	#include <features.h>
++	#if defined(__UCLIBC__)
++	LIBC=uclibc
++	#elif defined(__dietlibc__)
++	LIBC=dietlibc
++	#else
++	LIBC=gnu
++	#endif
++	EOF
++	eval `$CC_FOR_BUILD -E $dummy.c 2>/dev/null | grep '^LIBC' | sed 's, ,,g'`
++	;;
++esac
++
+ # Note: order is significant - the case branches are not exclusive.
+ 
+ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+@@ -861,6 +882,13 @@
+     i*86:Minix:*:*)
+ 	echo ${UNAME_MACHINE}-pc-minix
+ 	exit ;;
++    aarch64:Linux:*:*)
++        echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++        exit ;;
++    aarch64_be:Linux:*:*)
++        UNAME_MACHINE=aarch64_be
++        echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++        exit ;;
+     alpha:Linux:*:*)
+ 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
+ 	  EV5)   UNAME_MACHINE=alphaev5 ;;
 diff -NrU3 binutils-2.23.2/configure binutils-2.23.2-patched/configure
 --- binutils-2.23.2/configure	2012-06-28 13:50:52.000000000 +0200
 +++ binutils-2.23.2-patched/configure	2020-04-23 17:57:30.323522816 +0200

--- a/patches/gdb-7.5.1-PSP.patch
+++ b/patches/gdb-7.5.1-PSP.patch
@@ -100,6 +100,50 @@ diff -NrU3 gdb-7.5/config.sub gdb-7.5-patched/config.sub
  	mips3*-*)
  		basic_machine=`echo $basic_machine | sed -e 's/mips3/mips64/'`
  		;;
+--- gdb-7.5.1/config.guess	2021-02-14 16:35:28.201894642 +0800
++++ gdb-7.5.1-patched/config.guess	2021-02-14 16:36:42.841894677 +0800
+@@ -140,6 +140,27 @@
+ UNAME_SYSTEM=`(uname -s) 2>/dev/null`  || UNAME_SYSTEM=unknown
+ UNAME_VERSION=`(uname -v) 2>/dev/null` || UNAME_VERSION=unknown
+ 
++case "${UNAME_SYSTEM}" in
++Linux|GNU|GNU/*)
++	# If the system lacks a compiler, then just pick glibc.
++	# We could probably try harder.
++	LIBC=gnu
++
++	eval $set_cc_for_build
++	cat <<-EOF > $dummy.c
++	#include <features.h>
++	#if defined(__UCLIBC__)
++	LIBC=uclibc
++	#elif defined(__dietlibc__)
++	LIBC=dietlibc
++	#else
++	LIBC=gnu
++	#endif
++	EOF
++	eval `$CC_FOR_BUILD -E $dummy.c 2>/dev/null | grep '^LIBC' | sed 's, ,,g'`
++	;;
++esac
++
+ # Note: order is significant - the case branches are not exclusive.
+ 
+ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+@@ -861,6 +882,13 @@
+     i*86:Minix:*:*)
+ 	echo ${UNAME_MACHINE}-pc-minix
+ 	exit ;;
++    aarch64:Linux:*:*)
++        echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++        exit ;;
++    aarch64_be:Linux:*:*)
++        UNAME_MACHINE=aarch64_be
++        echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++        exit ;;
+     alpha:Linux:*:*)
+ 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
+ 	  EV5)   UNAME_MACHINE=alphaev5 ;;
 diff -NrU3 gdb-7.5/include/elf/common.h gdb-7.5-patched/include/elf/common.h
 --- gdb-7.5/include/elf/common.h	2012-06-28 11:12:27.000000000 +0200
 +++ gdb-7.5-patched/include/elf/common.h	2020-04-23 18:23:00.707745070 +0200

--- a/scripts/004-newlib-1.20.0.sh
+++ b/scripts/004-newlib-1.20.0.sh
@@ -5,7 +5,7 @@
  set -e
 
  ## Download the source code if it does not already exist.
-clone_git_repo github.com lrdshaper newlib newlib-1_20_0-PSP
+clone_git_repo github.com pspdev newlib newlib-1_20_0-PSP
 
  ## Enter the source directory
  cd newlib

--- a/scripts/004-newlib-1.20.0.sh
+++ b/scripts/004-newlib-1.20.0.sh
@@ -5,7 +5,7 @@
  set -e
 
  ## Download the source code if it does not already exist.
-clone_git_repo github.com pspdev newlib newlib-1_20_0-PSP
+clone_git_repo github.com lrdshaper newlib newlib-1_20_0-PSP
 
  ## Enter the source directory
  cd newlib


### PR DESCRIPTION
Updated patch for binutils and gdb to add support for aarch64. Tested on Pine64 (Debian 9 & 10) and Rock64 (Debian 10)