### PR TITLE
Add --with-sysroot for CMake CMAKE_USE_SYSROOT command

### DIFF
--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -23,7 +23,7 @@ CFLAGS="$CFLAGS -I/opt/local/include" \
   CPPFLAGS="$CPPFLAGS -I/opt/local/include" \
   LDFLAGS="$LDFLAGS -L/opt/local/lib" \
   ../configure --prefix="$PSPDEV" --target="psp" --enable-install-libbfd \
-  --enable-plugins --disable-werror --with-system-zlib
+  --enable-plugins --disable-werror --with-system-zlib -with-sysroot="$PSPDEV"
 
 # Compile and install. ( -r is required for building under osx )
 make -j $(num_cpus) clean

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -44,7 +44,7 @@
    CPPFLAGS="$CPPFLAGS -I/opt/local/include" \
    LDFLAGS="$LDFLAGS -L/opt/local/lib" \
    ../configure --prefix="$PSPDEV" --target="psp" --enable-languages="c" \
-   --enable-lto --with-newlib --without-headers --disable-libssp
+   --enable-lto --with-newlib --without-headers --disable-libssp -with-sysroot="$PSPDEV"
 
  ## Compile and install.
  make -j $(num_cpus) clean

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -46,7 +46,7 @@
    CPPFLAGS="$CPPFLAGS -I/opt/local/include" \
    LDFLAGS="$LDFLAGS -L/opt/local/lib" \
    ../configure --prefix="$PSPDEV" --target="psp" --enable-languages="c,c++" \
-   --enable-lto --with-newlib --enable-cxx-flags="-G0"
+   --enable-lto --with-newlib --enable-cxx-flags="-G0" -with-sysroot="$PSPDEV"
 
  ## Compile and install.
  make -j $(num_cpus) clean


### PR DESCRIPTION
--with-sysroot is required to use CMAKE_GET_SYSROOT.

What it does: Tells GCC to consider dir as the root of a tree that contains (a subset of) the root filesystem of the target operating system. Target system headers, libraries and run-time object files will be searched for in there. More specifically, this acts as if --sysroot=dir was added to the default options of the built compiler. The specified directory is not copied into the install tree, unlike the options --with-headers and --with-libs that this option obsoletes. The default value, in case --with-sysroot is not given an argument, is ${gcc_tooldir}/sys-root. If the specified directory is a subdirectory of ${exec_prefix}, then it will be found relative to the GCC binaries if the installation tree is moved. 