### PR TITLE
Fix gdb 7.5.1 build on macOS

### DIFF
--- a/patches/gdb-7.5.1-fixes-macos.patch
+++ b/patches/gdb-7.5.1-fixes-macos.patch
@@ -1,0 +1,31 @@
+--- gdb-7.5.1_org/sim/common/gentmap.c	2012-05-19 18:46:14.000000000 +0200
++++ gdb-7.5.1/sim/common/gentmap.c	2021-08-14 14:56:42.000000000 +0200
+@@ -2,6 +2,7 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <string.h>
+ 
+ struct tdefs {
+   char *symbol;
+diff -NrU3 gdb-7.5.1_org/readline/rltty.c gdb-7.5.1/readline/rltty.c
+--- gdb-7.5.1_org/readline/rltty.c	2011-05-12 01:38:39.000000000 +0200
++++ gdb-7.5.1/readline/rltty.c	2021-08-16 20:17:14.000000000 +0200
+@@ -30,6 +30,7 @@
+ #include <signal.h>
+ #include <errno.h>
+ #include <stdio.h>
++#include <sys/ioctl.h>
+ 
+ #if defined (HAVE_UNISTD_H)
+ #  include <unistd.h>
+--- gdb-7.5.1_org/readline/terminal.c	2011-05-12 01:38:39.000000000 +0200
++++ gdb-7.5.1/readline/terminal.c	2021-08-16 21:01:55.000000000 +0200
+@@ -47,6 +47,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <sys/ioctl.h>
+ 
+ /* System-specific feature definitions and include files. */
+ #include "rldefs.h"

--- a/scripts/007-gdb.sh
+++ b/scripts/007-gdb.sh
@@ -13,6 +13,9 @@ download_and_extract https://ftp.gnu.org/gnu/gdb/gdb-$GDB_VERSION.tar.bz2 gdb-$G
 cd gdb-"$GDB_VERSION"
 patch -p1 < ../../patches/gdb-"$GDB_VERSION"-PSP.patch
 patch -p1 < ../../patches/gdb-"$GDB_VERSION"-fixes.patch
+if [ "$(uname)" == "Darwin" ]; then
+  patch -p1 < ../../patches/gdb-"$GDB_VERSION"-fixes-macos.patch
+fi
 
 # Create and enter the build directory.
 mkdir build-psp


### PR DESCRIPTION
This PR fixes #153. 
Additional patch for sake of macOS building.
Verified on macOS Big Sur 11.2.3 (20D91).
Adds ioctl.h/string.h includes to following files :
- readline/terminal.c
- readline/rltty.c
- sim/common/gentmap.c
