### PR TITLE
Revert "Workflow: Enable nightly deployment of Docker container"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,6 @@ on:
       - master
     tags:
       - v*
-  schedule:
-      - cron: 0 7 * * *
   repository_dispatch:
     types: [run_build]
 


### PR DESCRIPTION
We've decided we prefer to go with weekly builds and trigger it from the lowest repo in the chain of triggering builds on different repos. I'm going to create pull requests for psptoolchain-allegrex and psp-pacman.