### PR TITLE
Use alpine 3.16 to fix build error

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   build-docker:
     runs-on: ubuntu-latest
-    container: ${{ matrix.os[0] }}:latest
+    container: ${{ matrix.os[0] }}:${{ matrix.os[1] }}
     strategy:
       matrix:
-        os: [[alpine, bash], [fedora, bash]]
+        os: [[alpine, 3.16], [fedora, latest]]
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
This should be temporary, since 3.19 will fix this. It's broken in 3.17 and 3.18, though, which is a shame.