### PR TITLE
Do not rely on already available package list

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Install dependencies Alpine
       if: matrix.os[0] == 'alpine'
       run: |
-        apk add build-base bash gcc git make autoconf automake python3 py3-pip cmake pkgconfig libarchive-dev openssl-dev gpgme-dev libtool \
-          flex bison texinfo gmp-dev mpfr-dev mpc1-dev readline-dev ncurses-dev
+        apk add --no-cache build-base bash gcc git make autoconf automake python3 py3-pip cmake pkgconfig libarchive-dev openssl-dev gpgme-dev \
+          libtool flex bison texinfo gmp-dev mpfr-dev mpc1-dev readline-dev ncurses-dev
     
     - name: Install dependencies Fedora
       if: matrix.os[0] == 'fedora'
@@ -64,7 +64,8 @@ jobs:
     - name: Install Dependencies Ubuntu 
       if: matrix.os[0] == 'ubuntu-latest'
       run: |
-        sudo apt-get -y install libarchive-dev libcurl4 libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev \
+        sudo apt-get update
+        sudo apt-get -y install libcurl4 libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev \
           gettext texinfo bison flex libncurses5-dev libgmp3-dev libmpfr-dev libmpc-dev
         echo "MSYSTEM=x64" >> $GITHUB_ENV
 


### PR DESCRIPTION
apt and apk do manage their own package lists, but those can be outdated and require an update. This change makes it so that happens, which should prevent some failures.