### PR TITLE
Do not create releases upon tag creation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - v*
   repository_dispatch:
     types: [run_build]
 
@@ -16,17 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Extract DOCKER_TAG using tag name
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        echo "DOCKER_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-    
-
-    - name: Use default DOCKER_TAG
-      if: startsWith(github.ref, 'refs/tags/') != true
-      run: |
-        echo "DOCKER_TAG=latest" >> $GITHUB_ENV
-    
     - name: Login to Github registry
       uses: docker/login-action@v3
       with:
@@ -37,10 +24,10 @@ jobs:
     - uses: docker/build-push-action@v5
       with:
         push: true
-        tags: ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}
+        tags: ghcr.io/${{ github.repository }}:latest
         build-args: |
-          BASE_DOCKER_ALLEGREX_IMAGE=ghcr.io/${{ github.repository_owner }}/psptoolchain-allegrex:${{ env.DOCKER_TAG }}
-          BASE_DOCKER_EXTRA_IMAGE=ghcr.io/${{ github.repository_owner }}/psptoolchain-extra:${{ env.DOCKER_TAG }}
+          BASE_DOCKER_ALLEGREX_IMAGE=ghcr.io/${{ github.repository_owner }}/psptoolchain-allegrex:latest
+          BASE_DOCKER_EXTRA_IMAGE=ghcr.io/${{ github.repository_owner }}/psptoolchain-extra:latest
 
     - name: Send Compile action
       run: |


### PR DESCRIPTION
We'd like to move away from tagging from the bottom up because of the complexity it brings. It's nicer to always use latest.