### PR TITLE
Build for Fedora 41

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [
           [alpine, latest], 
-          [fedora, latest],
+          [fedora, 41],
         ]
       fail-fast: false
     steps:


### PR DESCRIPTION
42 is stil broken for now, binutils does not build with gcc 15.