### PR TITLE
Update dependencies for Debian 13 (Trixie)

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -22,13 +22,13 @@ else
 
     ubuntu | debian)
         sudo apt-get update
-        sudo apt-get -y install texinfo bison flex gettext libgmp3-dev libmpfr-dev libmpc-dev libusb-dev libreadline-dev libcurl4 libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev \
-        libz-dev	
+        sudo apt-get -y install build-essential clang cmake git wget texinfo bison flex gettext libtool libgsl-dev libgmp3-dev libmpfr-dev libmpc-dev libusb-dev libreadline-dev libcurl4 \
+        libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev libz-dev python3 python3-pip python3-venv
     ;;
     rhel | fedora)
          dnf -y install @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \
           libarchive-devel openssl-devel gpgme-devel libtool gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel ncurses-devel diffutils \
-          libusb-compat-0.1-devel readline-devel libcurl-devel which glibc-gconv-extra xz gawk file 
+          libusb-compat-0.1-devel readline-devel libcurl-devel which glibc-gconv-extra xz gawk file
     ;;
     gentoo)
         sudo emerge --noreplace net-misc/wget dev-vcs/git dev-python/pip sys-apps/fakeroot \

--- a/prepare.sh
+++ b/prepare.sh
@@ -22,7 +22,7 @@ else
 
     ubuntu | debian)
         sudo apt-get update
-        sudo apt-get -y install build-essential clang cmake git wget texinfo bison flex gettext libtool libgsl-dev libgmp3-dev libmpfr-dev libmpc-dev libusb-dev libreadline-dev libcurl4 \
+        sudo apt-get -y install build-essential cmake git wget texinfo bison flex gettext libtool libgsl-dev libgmp3-dev libmpfr-dev libmpc-dev libusb-dev libreadline-dev libcurl4 \
         libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev libz-dev python3 python3-pip python3-venv
     ;;
     rhel | fedora)


### PR DESCRIPTION
Running `toolchain.sh` on Debian 13.3 (Trixie) previously failed due to missing build dependencies.
This pull request adds necessary additional dependencies to `prepare.sh`.
Tested successfully on Debian 13.3.